### PR TITLE
Pressing ctrl+c in input once clears text, twice exits app

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -33,7 +33,7 @@ import { displayLog } from "./logger.ts";
 import { CenteredBox } from "./components/centered-box.tsx";
 import { Transport } from "./transports/transport-common.ts";
 import { LocalTransport } from "./transports/local.ts";
-import { CtrlCProvider, useCtrlC } from "./components/ctrl-c-provider.tsx";
+import { CtrlCContext, CtrlCProvider } from "./components/ctrl-c-provider.tsx";
 
 type Props = {
 	config: Config;
@@ -127,7 +127,7 @@ function BottomBar({ metadata }: {
 }) {
   const [ versionCheck, setVersionCheck ] = useState("Checking for updates...");
   const themeColor = useColor();
-  const { ctrlCPressed } = useCtrlC();
+  const { ctrlCPressed } = useContext(CtrlCContext);
   const { modeData } = useAppStore(
     useShallow(state => ({
       modeData: state.modeData,
@@ -153,7 +153,7 @@ function BottomBar({ metadata }: {
     <BottomBarContent />
     <Box
       width="100%"
-      justifyContent={ctrlCPressed ? "space-between" : "flex-end"}
+      justifyContent="space-between"
       height={1}
       flexShrink={0}
       flexGrow={1}
@@ -185,7 +185,7 @@ async function getLatestVersion() {
 function BottomBarContent() {
   const config = useConfig();
   const transport = useContext(TransportContext);
-  const { registerClearInputFn } = useCtrlC();
+  const { registerClearInputFn } = useContext(CtrlCContext);
 	const [ query, setQuery ] = useState("");
   const { modeData, input, abortResponse, toggleMenu } = useAppStore(
     useShallow(state => ({

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -48,7 +48,10 @@ const cli = new Command()
       metadata={metadata}
       unchained={!!opts.unchained}
       transport={new LocalTransport()}
-    />
+    />,
+    {
+      exitOnCtrlC: false
+    }
   );
 
   await waitUntilExit();

--- a/source/components/ctrl-c-provider.tsx
+++ b/source/components/ctrl-c-provider.tsx
@@ -6,25 +6,20 @@ type CtrlCContextType = {
   registerClearInputFn: (clearFn: () => void) => void;
 };
 
-const CtrlCContext = createContext<CtrlCContextType>({
-  ctrlCPressed: false,
-  registerClearInputFn: () => {},
-});
-
-export function useCtrlC() {
-  return useContext(CtrlCContext);
-}
-
 type CtrlCProviderProps = {
   children: React.ReactNode;
 };
+
+export const CtrlCContext = createContext<CtrlCContextType>({
+  ctrlCPressed: false,
+  registerClearInputFn: () => {},
+});
 
 export function CtrlCProvider({ children }: CtrlCProviderProps) {
   const [ctrlCPressed, setCtrlCPressed] = useState(false);
   const clearInputRef = useRef<(() => void) | null>(null);
   const { exit } = useApp();
 
-  // Global input handler to capture Ctrl+C
   useInput((input, key) => {
     if (key.ctrl && input === 'c') {
       if (ctrlCPressed) {

--- a/source/components/ctrl-c-provider.tsx
+++ b/source/components/ctrl-c-provider.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useRef, createContext, useContext, useEffect } from "react";
+import { useInput, useApp } from "ink";
+
+type CtrlCContextType = {
+  ctrlCPressed: boolean;
+  registerClearInputFn: (clearFn: () => void) => void;
+};
+
+const CtrlCContext = createContext<CtrlCContextType>({
+  ctrlCPressed: false,
+  registerClearInputFn: () => {},
+});
+
+export function useCtrlC() {
+  return useContext(CtrlCContext);
+}
+
+type CtrlCProviderProps = {
+  children: React.ReactNode;
+};
+
+export function CtrlCProvider({ children }: CtrlCProviderProps) {
+  const [ctrlCPressed, setCtrlCPressed] = useState(false);
+  const clearInputRef = useRef<(() => void) | null>(null);
+  const { exit } = useApp();
+
+  // Global input handler to capture Ctrl+C
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') {
+      if (ctrlCPressed) {
+        exit();
+      } else {
+        if (clearInputRef.current) {
+          clearInputRef.current();
+        }
+        setCtrlCPressed(true);
+        setTimeout(() => setCtrlCPressed(false), 2000);
+      }
+    }
+  });
+
+  const registerClearInputFn = (clearFn: () => void) => {
+    clearInputRef.current = clearFn;
+  };
+
+  return (
+    <CtrlCContext.Provider value={{
+      ctrlCPressed,
+      registerClearInputFn,
+    }}>
+      {children}
+    </CtrlCContext.Provider>
+  );
+}


### PR DESCRIPTION
<img width="1004" height="272" alt="CleanShot 2025-08-18 at 18 16 21@2x" src="https://github.com/user-attachments/assets/ebba6e09-eb81-4111-869f-ada083a1c9e2" />

Feel like terminal users (like myself) are used to ctlr+c to clear input. :P

Kept most of the handling code in `components/ctrl-c-provider.tsx` to keep `app.tsx` clean. Also sets `exitOnCtrlC: false` to disable Ink's default handling of `SIGINT` so we can call `exit()` manually.