### PR TITLE
For edits and creates, repeat the question before the selection prompts.

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -276,6 +276,7 @@ function PaymentErrorScreen({ error }: { error: string }) {
 function ToolRequestRenderer({ toolReq, config, transport }: {
   toolReq: ToolCallItem
 } & RunArgs) {
+  const themeColor = useColor();
   const { runTool, rejectTool } = useAppStore(
     useShallow(state => ({
       runTool: state.runTool,
@@ -283,6 +284,30 @@ function ToolRequestRenderer({ toolReq, config, transport }: {
     }))
   );
   const unchained = useUnchained();
+
+  const prompt = (() => {
+    const fn = toolReq.tool.function;
+    switch (fn.name) {
+      case "create":
+        return <Box>
+          <Text>Create file </Text>
+          <Text color={themeColor}>{fn.arguments.filePath}</Text>
+          <Text>?</Text>
+        </Box>
+      case "edit":
+        return <Box>
+          <Text>Make these changes to </Text>
+          <Text color={themeColor}>{fn.arguments.filePath}</Text>
+          <Text>?</Text>
+        </Box>
+      case "read":
+      case "bash":
+      case "fetch":
+      case "list":
+      case "mcp":
+        return null;
+    }
+  })();
 
   const items = [
     {
@@ -309,12 +334,15 @@ function ToolRequestRenderer({ toolReq, config, transport }: {
 
   if(noConfirm) return <Loading />;
 
-  return <SelectInput
-    items={items}
-    onSelect={onSelect}
-    indicatorComponent={IndicatorComponent}
-    itemComponent={ItemComponent}
-  />
+  return <Box flexDirection="column" gap={1}>
+    { prompt }
+    <SelectInput
+      items={items}
+      onSelect={onSelect}
+      indicatorComponent={IndicatorComponent}
+      itemComponent={ItemComponent}
+    />
+  </Box>
 }
 
 
@@ -521,13 +549,13 @@ function DiffEditRenderer({ item }: { item: t.GetType<typeof edit.DiffEdit> }) {
 
 function CreateToolRenderer({ item }: { item: t.GetType<typeof createTool.Schema> }) {
   const themeColor = useColor();
-  return <Box flexDirection="column">
+  return <Box flexDirection="column" gap={1}>
     <Box>
-      <Text>Create file: </Text>
+      <Text>Creating file </Text>
       <Text color={themeColor}>{item.arguments.filePath}</Text>
+      <Text>:</Text>
     </Box>
-    <Box flexDirection="column">
-      <Text>With content:</Text>
+    <Box>
       <Text>{item.arguments.content}</Text>
     </Box>
   </Box>


### PR DESCRIPTION
Repeats the query for `create` and `edit` tools, which can output long files and diffs.

Before:
(writing a markdown file)
<img width="834" height="400" alt="CleanShot 2025-08-18 at 18 19 48@2x" src="https://github.com/user-attachments/assets/eed95744-aed9-4b2e-80c9-f1975efff971" />

After:

<img width="1138" height="204" alt="CleanShot 2025-08-18 at 18 37 57@2x" src="https://github.com/user-attachments/assets/c401c0a4-90cb-447e-96cf-e591acd89bf0" />


Also slightly updates the UI for the create renderer to be more grokable:

Before:
<img width="808" height="198" alt="CleanShot 2025-08-18 at 18 19 42@2x" src="https://github.com/user-attachments/assets/ec77f455-1d11-4951-bbcf-4d02ff1d713a" />

After:
<img width="1074" height="212" alt="CleanShot 2025-08-18 at 18 37 01@2x" src="https://github.com/user-attachments/assets/7649fa34-3e81-493a-a196-5c2a3fe1f457" />
