### PR TITLE
Make UI less sparse

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -357,7 +357,7 @@ const StaticItemRenderer = React.memo(({ item }: { item: StaticItem }) => {
 const MessageDisplay = React.memo(({ item }: {
   item: HistoryItem | Omit<AssistantItem, "id" | "tokenUsage"> // Allow inflight assistant messages
 }) => {
-  return <Box marginTop={1} marginBottom={1} flexDirection="column" paddingRight={4}>
+  return <Box marginBottom={1} flexDirection="column" paddingRight={4}>
     <MessageDisplayInner item={item} />
   </Box>
 });


### PR DESCRIPTION
Tiny proposal to slightly reduce the assistant output sparseness to one line (especially since we already have the friendly octo icon :))

Kept `marginBottom` to preserve formatting with non-static elements that come after. Could be slightly improved to remove the line between the tool prompt and result but this change was trivial. :P

Before:
<img width="3234" height="1102" alt="CleanShot 2025-08-18 at 19 17 37@2x" src="https://github.com/user-attachments/assets/65732117-c7c6-4b6a-92b9-a26eb5c8b0ef" />

After:
<img width="3110" height="1330" alt="CleanShot 2025-08-18 at 19 18 23@2x" src="https://github.com/user-attachments/assets/0dcf6289-8673-4329-8703-02d2edaa08c7" />
