### PR TITLE
Fix read tool to actually output number of lines from file

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -371,8 +371,12 @@ const MessageDisplayInner = React.memo(({ item }: {
 	if(item.type === "assistant") return <AssistantMessageRenderer item={item} />
 	if(item.type === "tool") return <ToolMessageRenderer item={item} />
 	if(item.type === "tool-output") {
+    // The read tool outputs the number of lines read instead of file content.
+    const numLines = item.tool.name === "read"
+      ? item.content
+      : item.content.split("\n").length;
 		return <Text color="gray">
-			Got <Text>{item.content.split("\n").length}</Text> lines of output
+			Got {numLines} lines of output
 		</Text>
 	}
   if(item.type === "tool-malformed") {

--- a/source/history.ts
+++ b/source/history.ts
@@ -20,6 +20,10 @@ export type ToolCallItem = SequenceIdTagged<{
 
 export type ToolOutputItem = SequenceIdTagged<{
 	type: "tool-output",
+  tool: {
+    type: "function",
+    name: t.GetType<typeof ToolCallSchema>["name"],
+  },
 	content: string,
   toolCallId: string,
 }>;

--- a/source/state.ts
+++ b/source/state.ts
@@ -177,6 +177,10 @@ export const useAppStore = create<UiState>((set, get) => ({
         id: sequenceId(),
         content,
         toolCallId: toolReq.tool.toolCallId,
+        tool: {
+          type: "function",
+          name: toolReq.tool.function.name,
+        }
       };
 
       const history: HistoryItem[] = [

--- a/source/tools/tool-defs/read.ts
+++ b/source/tools/tool-defs/read.ts
@@ -8,7 +8,7 @@ const ArgumentsSchema = t.subtype({
 const Schema = t.subtype({
  name: t.value("read"),
  arguments: ArgumentsSchema,
-}).comment("Reads file contents as UTF-8. Prefer this to Unix tools like `cat`");
+}).comment("Reads file contents as UTF-8. Prefer this to Unix tools like `cat`. Returns number of lines in file as string.");
 
 export default {
   Schema, ArgumentsSchema,
@@ -20,8 +20,8 @@ export default {
     const { filePath } = call.tool.arguments;
     return attempt(`No such file ${filePath}`, async () => {
       // Actually perform the read to ensure it's readable, and that the timestamps get updated
-      await fileTracker.read(transport, abortSignal, filePath)
-      return "";
+      const content = await fileTracker.read(transport, abortSignal, filePath)
+      return content.split("\n").length.toString();
     });
   },
 } satisfies ToolDef<t.GetType<typeof Schema>>;


### PR DESCRIPTION
Before:

<img width="844" height="310" alt="CleanShot 2025-08-18 at 19 42 15@2x" src="https://github.com/user-attachments/assets/20c412f2-0fc5-4fd6-9bb3-587378779648" />

After:

<img width="696" height="276" alt="CleanShot 2025-08-18 at 19 41 06@2x" src="https://github.com/user-attachments/assets/3f74446e-ec21-40e7-89cc-b594267a6d06" />


Since the read tool was returning an empty output anyways, decided to just output the num lines instead of putting raw file contents into history, which we obv don't want, or complicating the tool interface.