### PR TITLE
Enable ctrl-a, ctrl-e, and ctrl-w shortcuts in user input box

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"ink": "^5.2.0",
 		"ink-select-input": "^6.0.0",
 		"ink-spinner": "^5.0.0",
-		"ink-text-input": "^6.0.0",
 		"json-schema": "^0.4.0",
 		"json5": "^2.2.3",
 		"openai": "^5.9.0",

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -3,7 +3,7 @@ import React, {
   useState, useCallback, useMemo, useEffect, useRef, createContext, useContext
 } from "react";
 import { Text, Box, Static, measureElement, DOMElement, useInput } from "ink";
-import TextInput from "ink-text-input";
+import TextInput from "./components/text-input.tsx";
 import { t } from "structural";
 import {
   Config, Metadata, ConfigContext, ConfigPathContext, SetConfigContext, useConfig

--- a/source/components/add-model-flow.tsx
+++ b/source/components/add-model-flow.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, createContext, useContext } from "react";
 import { Box, Text } from "ink";
-import TextInput from "ink-text-input";
+import TextInput from "./text-input.tsx";
 import { Config, assertKeyForModel } from "../config.ts";
 import { useColor } from "../theme.ts";
 import OpenAI from "openai";

--- a/source/components/set-api-key.tsx
+++ b/source/components/set-api-key.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { Box, Text, useInput } from "ink";
-import TextInput from "ink-text-input";
+import TextInput from "./text-input.tsx";
 import { CenteredBox } from "./centered-box.tsx";
 import { MenuHeader } from "./menu-panel.tsx";
 import { writeKeyForModel } from "../config.ts";

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Text, useInput } from 'ink';
 import chalk from 'chalk';
 
-export type Props = {
+type Props = {
 	readonly placeholder?: string;
 	readonly focus?: boolean;
 	readonly mask?: string;
@@ -13,7 +13,7 @@ export type Props = {
 	readonly onSubmit?: (value: string) => void;
 };
 
-export function TextInput({
+export default function TextInput({
 	value: originalValue,
 	placeholder = '',
 	focus = true,
@@ -105,7 +105,82 @@ export function TextInput({
 			let nextValue = originalValue;
 			let nextCursorWidth = 0;
 
-			if (key.leftArrow) {
+			if (key.ctrl && input === 'a') {
+				nextCursorOffset = 0;
+			} else if (key.ctrl && input === 'e') {
+				nextCursorOffset = originalValue.length;
+			} else if (key.ctrl && input === 'b') {
+				if (showCursor && cursorOffset > 0) {
+					nextCursorOffset = cursorOffset - 1;
+				}
+			} else if (key.ctrl && input === 'f') {
+				if (showCursor && cursorOffset < originalValue.length) {
+					nextCursorOffset = cursorOffset + 1;
+				}
+			} else if (key.meta && input === 'b') {
+				if (showCursor && cursorOffset > 0) {
+					let wordStart = cursorOffset;
+					while (wordStart > 0 && /\s/.test(originalValue[wordStart - 1])) {
+						wordStart--;
+					}
+					while (wordStart > 0 && !/\s/.test(originalValue[wordStart - 1])) {
+						wordStart--;
+					}
+					nextCursorOffset = wordStart;
+				}
+			} else if (key.meta && input === 'f') {
+				if (showCursor && cursorOffset < originalValue.length) {
+					let wordEnd = cursorOffset;
+					while (wordEnd < originalValue.length && /\s/.test(originalValue[wordEnd])) {
+						wordEnd++;
+					}
+					while (wordEnd < originalValue.length && !/\s/.test(originalValue[wordEnd])) {
+						wordEnd++;
+					}
+					nextCursorOffset = wordEnd;
+				}
+			} else if (key.ctrl && input === 'w') {
+				if (cursorOffset > 0) {
+					let wordStart = cursorOffset;
+					while (wordStart > 0 && /\s/.test(originalValue[wordStart - 1])) {
+						wordStart--;
+					}
+					while (wordStart > 0 && !/\s/.test(originalValue[wordStart - 1])) {
+						wordStart--;
+					}
+					nextValue = originalValue.slice(0, wordStart) + originalValue.slice(cursorOffset);
+					nextCursorOffset = wordStart;
+				}
+			} else if (key.ctrl && input === 'h') {
+				if (cursorOffset > 0) {
+					nextValue =
+						originalValue.slice(0, cursorOffset - 1) +
+						originalValue.slice(cursorOffset, originalValue.length);
+					nextCursorOffset = cursorOffset - 1;
+				}
+			} else if (key.ctrl && input === 'd') {
+				if (cursorOffset < originalValue.length) {
+					nextValue =
+						originalValue.slice(0, cursorOffset) +
+						originalValue.slice(cursorOffset + 1, originalValue.length);
+				}
+			} else if (key.meta && input === 'd') {
+				if (cursorOffset < originalValue.length) {
+					let wordEnd = cursorOffset;
+					while (wordEnd < originalValue.length && /\s/.test(originalValue[wordEnd])) {
+						wordEnd++;
+					}
+					while (wordEnd < originalValue.length && !/\s/.test(originalValue[wordEnd])) {
+						wordEnd++;
+					}
+					nextValue = originalValue.slice(0, cursorOffset) + originalValue.slice(wordEnd);
+				}
+			} else if (key.ctrl && input === 'k') {
+				nextValue = originalValue.slice(0, cursorOffset);
+			} else if (key.ctrl && input === 'u') {
+				nextValue = originalValue.slice(cursorOffset);
+				nextCursorOffset = 0;
+			} else if (key.leftArrow) {
 				if (showCursor) {
 					nextCursorOffset--;
 				}

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useEffect } from 'react';
+import { Text, useInput } from 'ink';
+import chalk from 'chalk';
+
+export type Props = {
+  readonly placeholder?: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly onSubmit?: (value: string) => void;
+};
+
+function TextInput({ placeholder = '', value, onChange, onSubmit }: Props): React.JSX.Element {
+  const [cursorOffset, setCursorOffset] = useState(value.length);
+
+  useEffect(() => {
+    setCursorOffset(prevOffset => Math.min(prevOffset, value.length));
+  }, [value]);
+
+  const renderWithCursor = () => {
+    if (value.length === 0) {
+      return placeholder.length > 0
+        ? chalk.inverse(placeholder[0]) + chalk.grey(placeholder.slice(1))
+        : chalk.inverse(' ');
+    }
+
+    let result = '';
+    for (let i = 0; i < value.length; i++) {
+      result += i === cursorOffset ? chalk.inverse(value[i]) : value[i];
+    }
+    if (cursorOffset === value.length) {
+      result += chalk.inverse(' ');
+    }
+    return result;
+  };
+
+  useInput((input, key) => {
+    if (key.upArrow || key.downArrow || (key.ctrl && input === 'c') || key.tab || (key.shift && key.tab)) {
+      return;
+    }
+
+    if (key.return) {
+      onSubmit?.(value);
+      return;
+    }
+
+    let nextCursorOffset = cursorOffset;
+    let nextValue = value;
+
+    if (key.ctrl && input === 'a') {
+      nextCursorOffset = 0;
+    } else if (key.ctrl && input === 'e') {
+      nextCursorOffset = value.length;
+    } else if (key.ctrl && input === 'w') {
+      if (cursorOffset > 0) {
+        let wordStart = cursorOffset;
+        while (wordStart > 0 && /\s/.test(value[wordStart - 1])) {
+          wordStart--;
+        }
+        while (wordStart > 0 && !/\s/.test(value[wordStart - 1])) {
+          wordStart--;
+        }
+        nextValue = value.slice(0, wordStart) + value.slice(cursorOffset);
+        nextCursorOffset = wordStart;
+      }
+    } else if (key.leftArrow) {
+      nextCursorOffset--;
+    } else if (key.rightArrow) {
+      nextCursorOffset++;
+    } else if (key.backspace || key.delete) {
+      if (cursorOffset > 0) {
+        nextValue = value.slice(0, cursorOffset - 1) + value.slice(cursorOffset);
+        nextCursorOffset--;
+      }
+    } else {
+      nextValue = value.slice(0, cursorOffset) + input + value.slice(cursorOffset);
+      nextCursorOffset += input.length;
+    }
+
+    nextCursorOffset = Math.max(0, Math.min(nextCursorOffset, nextValue.length));
+
+    setCursorOffset(nextCursorOffset);
+
+    if (nextValue !== value) {
+      onChange(nextValue);
+    }
+  });
+
+  return <Text>{renderWithCursor()}</Text>;
+}
+
+export default TextInput;

--- a/source/first-time-setup.tsx
+++ b/source/first-time-setup.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput, useApp } from "ink";
 import fs from "fs/promises";
 import path from "path";
 import json5 from "json5";
-import TextInput from "ink-text-input";
+import TextInput from "./components/text-input.tsx";
 import { Config } from "./config.ts";
 import { useColor } from "./theme.ts";
 import { ModelSetup } from "./components/auto-detect-models.tsx";


### PR DESCRIPTION
Re-implements the `TextInput` component to enable terminal like shortcuts.

Also tested with the other inputs, like the onboarding name and custom model and inputs.

https://github.com/user-attachments/assets/ae2a01c1-a9f3-485a-bf26-2ae16dec6e44