### PR TITLE
Custom implementation of markdown terminal rendering with marked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,10 @@
 				"ink-text-input": "^6.0.0",
 				"json-schema": "^0.4.0",
 				"json5": "^2.2.3",
+				"marked": "^16.2.0",
 				"openai": "^5.9.0",
 				"react": "^18.2.0",
+				"string-width": "^7.2.0",
 				"structural": "^0.0.29",
 				"zustand": "^5.0.3"
 			},
@@ -2796,6 +2798,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
+			}
+		},
+		"node_modules/marked": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.2.0.tgz",
+			"integrity": "sha512-LbbTuye+0dWRz2TS9KJ7wsnD4KAtpj0MVkWc90XvBa6AslXsT0hTBVH5k32pcSyHH1fst9XEFJunXHktVy0zlg==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
 	"files": [
 		"dist",
 		"source",
-    "drizzle",
-    "drizzle.config.ts",
-    "CHANGELOG.md",
-    "IN-APP-UPDATES.txt",
+		"drizzle",
+		"drizzle.config.ts",
+		"CHANGELOG.md",
+		"IN-APP-UPDATES.txt",
 		"package.json",
 		"package-lock.json",
 		"tsconfig.json"
@@ -51,8 +51,10 @@
 		"ink-text-input": "^6.0.0",
 		"json-schema": "^0.4.0",
 		"json5": "^2.2.3",
+		"marked": "^16.2.0",
 		"openai": "^5.9.0",
 		"react": "^18.2.0",
+		"string-width": "^7.2.0",
 		"structural": "^0.0.29",
 		"zustand": "^5.0.3"
 	},
@@ -70,16 +72,15 @@
 		"typescript": "^5.8.3",
 		"vitest": "^3.2.4"
 	},
-
-  "overrides": {
-    "@esbuild-kit/core-utils": {
-      "esbuild": "0.25.0"
-    },
-    "@esbuild-kit/esm-loader": {
-      "esbuild": "0.25.0"
-    },
-    "drizzle-kit": {
-      "esbuild": "0.25.0"
-    }
-  }
+	"overrides": {
+		"@esbuild-kit/core-utils": {
+			"esbuild": "0.25.0"
+		},
+		"@esbuild-kit/esm-loader": {
+			"esbuild": "0.25.0"
+		},
+		"drizzle-kit": {
+			"esbuild": "0.25.0"
+		}
+	}
 }

--- a/scripts/dev/markdown-demo.ts
+++ b/scripts/dev/markdown-demo.ts
@@ -1,0 +1,192 @@
+import { renderMarkdown } from "../../source/markdown.ts";
+
+const demoMarkdown = `# Markdown Rendering Demo
+
+This demonstrates all the **beautiful** markdown rendering features with *aesthetic* terminal output.
+
+## Headings at Different Levels
+
+### Third Level Heading
+#### Fourth Level Heading
+##### Fifth Level Heading
+###### Sixth Level Heading
+
+## Text Formatting
+
+Here's some **bold text** and *italic text* and ~~strikethrough text~~.
+
+You can also have **bold with *nested italic* text** for complex formatting.
+
+## Code Examples
+
+Inline code like \`npm install\` is highlighted with inverse colors.
+
+### Code Blocks with Languages
+
+\`\`\`javascript
+function greetUser(name) {
+  console.log(\`Hello, \${name}!\`);
+  return {
+    message: "Welcome to our app",
+    timestamp: new Date().toISOString()
+  };
+}
+
+greetUser("Alice");
+\`\`\`
+
+\`\`\`bash
+# Install dependencies
+npm install
+
+# Run the application
+npm start
+
+# Run tests
+npm test
+\`\`\`
+
+\`\`\`python
+def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n-1) + fibonacci(n-2)
+
+# Generate first 10 Fibonacci numbers
+for i in range(10):
+    print(f"F({i}) = {fibonacci(i)}")
+\`\`\`
+
+### Code Block without Language
+
+\`\`\`
+This is plain code
+without syntax highlighting
+but still nicely formatted
+\`\`\`
+
+## Lists
+
+### Unordered Lists
+
+- First item with **bold** text
+- Second item with *italic* text
+- Third item with \`inline code\`
+  - Nested item one
+  - Nested item two
+- Fourth item with [a link](https://example.com)
+
+### Ordered Lists
+
+1. First numbered item
+2. Second numbered item with **formatting**
+3. Third numbered item
+   - Mixed with unordered
+   - Another nested item
+4. Fourth numbered item
+
+### Task Lists
+
+- [ ] Todo item not completed
+- [x] Completed task item
+- [ ] Another todo with *italic* text
+- [x] Done task with **bold** text
+
+## Links and Images
+
+Here's a [link to GitHub](https://github.com) and here's an ![example image](https://example.com/image.png).
+
+You can also have [links with **bold text**](https://example.com/bold) inside them.
+
+## Blockquotes
+
+> This is a blockquote with important information.
+> 
+> It can span multiple lines and contain **formatted text** and \`code\`.
+>
+> > Nested blockquotes are also supported
+> > with proper indentation.
+
+## Tables
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| **Headings** | ✅ | Colorful with different symbols |
+| *Formatting* | ✅ | Bold, italic, strikethrough |
+| \`Code\` | ✅ | Syntax highlighting boxes |
+| Links | ✅ | Blue underlined with URLs |
+| Tables | ✅ | Clean borders and formatting |
+
+## Horizontal Rules
+
+Here's some content above.
+
+---
+
+And here's content below the horizontal rule.
+
+## Complex Mixed Content
+
+This section combines multiple elements:
+
+### Example: Setting Up a Project
+
+1. **Initialize** the project:
+   \`\`\`bash
+   mkdir my-project
+   cd my-project
+   npm init -y
+   \`\`\`
+
+2. **Install** dependencies:
+   - Run \`npm install express\` for the web server
+   - Run \`npm install --save-dev typescript\` for TypeScript
+
+3. **Create** your main file:
+   \`\`\`typescript
+   import express from 'express';
+   
+   const app = express();
+   const PORT = process.env.PORT || 3000;
+   
+   app.get('/', (req, res) => {
+     res.json({ message: 'Hello, World!' });
+   });
+   
+   app.listen(PORT, () => {
+     console.log(\`Server running on port \${PORT}\`);
+   });
+   \`\`\`
+
+4. **Configure** TypeScript:
+   > Create a \`tsconfig.json\` file with your compiler options.
+   > Make sure to set \`"target": "ES2020"\` for modern features.
+
+5. **Deploy** when ready:
+   - [ ] Test locally with \`npm start\`
+   - [ ] Run tests with \`npm test\`
+   - [x] Deploy to production
+
+## Final Notes
+
+This demo shows the **complete range** of markdown rendering capabilities with:
+
+- 🎨 **Beautiful colors** for different element types
+- 📦 **Code blocks** with elegant borders
+- 📝 **Proper formatting** that's easy to read
+- 🔗 **Links** and images with clear indicators
+- 📊 **Tables** with clean structure
+- 💬 **Blockquotes** with distinctive styling
+
+The output is optimized for terminal display with *great contrast* and **readability**!
+`;
+
+console.log("🎨 Markdown Rendering Demo");
+console.log("=" .repeat(50));
+console.log();
+
+const rendered = renderMarkdown(demoMarkdown);
+console.log(rendered);
+
+console.log("=" .repeat(50));
+console.log("✨ Demo complete! All markdown features rendered above.");

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -34,6 +34,7 @@ import { CenteredBox } from "./components/centered-box.tsx";
 import { Transport } from "./transports/transport-common.ts";
 import { LocalTransport } from "./transports/local.ts";
 import { markUpdatesSeen } from "./update-notifs/update-notifs.ts";
+import { renderMarkdown } from "./markdown.ts";
 
 type Props = {
 	config: Config;
@@ -631,7 +632,7 @@ function AssistantMessageRenderer({ item }: { item: Omit<AssistantItem, "id" | "
         </Box>
       }
       <Box flexGrow={1}>
-        <Text>{content}</Text>
+        <Text>{renderMarkdown(content)}</Text>
       </Box>
     </Box>
   </Box>

--- a/source/markdown.test.ts
+++ b/source/markdown.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { renderMarkdown } from "./markdown.ts";
+
+// Force chalk to output colors in test environment
+beforeAll(() => {
+  process.env["FORCE_COLOR"] = '1';
+});
+
+// Helper function to strip ANSI codes for content checking
+function stripAnsi(str: string): string {
+  return str.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+// Helper function to check if content has been processed/formatted (not just plain text)
+function hasFormatting(str: string): boolean {
+  // Check for ANSI codes (colors), or typical markdown transformations
+  return /\u001b\[[0-9;]*m/.test(str) ||
+         str.includes('│') ||  // blockquote markers
+         str.includes('┌') ||  // code block borders
+         str.includes('█') ||  // heading markers
+         str.includes('•') ||  // list bullets
+         str !== str.trim();   // additional spacing/formatting
+}
+
+describe("renderMarkdown", () => {
+  describe("basic functionality", () => {
+    it("renders plain text and preserves content", () => {
+      const result = renderMarkdown("Hello world");
+      expect(stripAnsi(result)).toContain("Hello world");
+    });
+
+    it("preserves content across multiple lines", () => {
+      const result = renderMarkdown("First line\nSecond line");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("First line");
+      expect(stripped).toContain("Second line");
+    });
+  });
+
+  describe("headings", () => {
+    it("preserves heading text and applies formatting", () => {
+      const result = renderMarkdown("# Main Title\n## Subtitle");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Main Title");
+      expect(stripped).toContain("Subtitle");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles nested formatting in headings", () => {
+      const result = renderMarkdown("# Heading with **bold** text");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Heading with");
+      expect(stripped).toContain("bold");
+      expect(stripped).toContain("text");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("text formatting", () => {
+    it("preserves bold text content and applies formatting", () => {
+      const result = renderMarkdown("**bold text**");
+      expect(stripAnsi(result)).toContain("bold text");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("preserves italic text content and applies formatting", () => {
+      const result = renderMarkdown("*italic text*");
+      expect(stripAnsi(result)).toContain("italic text");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("preserves strikethrough text content and applies formatting", () => {
+      const result = renderMarkdown("~~strikethrough text~~");
+      expect(stripAnsi(result)).toContain("strikethrough text");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles mixed formatting", () => {
+      const result = renderMarkdown("**bold** and *italic* and ~~strike~~");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("bold");
+      expect(stripped).toContain("italic");
+      expect(stripped).toContain("strike");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("code", () => {
+    it("preserves inline code content and applies formatting", () => {
+      const result = renderMarkdown("`inline code`");
+      expect(stripAnsi(result)).toContain("inline code");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("preserves code block content and applies formatting", () => {
+      const code = "function test() {\n  return 'hello';\n}";
+      const result = renderMarkdown(`\`\`\`javascript\n${code}\n\`\`\``);
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("function test()");
+      expect(stripped).toContain("return 'hello'");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles code blocks without language", () => {
+      const result = renderMarkdown("```\nplain code\n```");
+      expect(stripAnsi(result)).toContain("plain code");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("links and images", () => {
+    it("preserves link content and applies formatting", () => {
+      const result = renderMarkdown("[link text](https://example.com)");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("link text");
+      expect(stripped).toContain("https://example.com");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("preserves image alt text", () => {
+      const result = renderMarkdown("![alt text](image.jpg)");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Image: alt text");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("lists", () => {
+    it("preserves unordered list content and applies formatting", () => {
+      const result = renderMarkdown("- Item 1\n- Item 2\n- Item 3");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Item 1");
+      expect(stripped).toContain("Item 2");
+      expect(stripped).toContain("Item 3");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("preserves ordered list content and applies formatting", () => {
+      const result = renderMarkdown("1. First\n2. Second\n3. Third");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("First");
+      expect(stripped).toContain("Second");
+      expect(stripped).toContain("Third");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles task lists", () => {
+      const result = renderMarkdown("- [ ] Todo\n- [x] Done");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Todo");
+      expect(stripped).toContain("Done");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles nested lists", () => {
+      const result = renderMarkdown("- Main\n  - Nested\n- Another");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Main");
+      expect(stripped).toContain("Nested");
+      expect(stripped).toContain("Another");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("blockquotes", () => {
+    it("preserves blockquote content and applies formatting", () => {
+      const result = renderMarkdown("> This is a quote");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("This is a quote");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles multi-line blockquotes", () => {
+      const result = renderMarkdown("> Line 1\n> Line 2");
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Line 1");
+      expect(stripped).toContain("Line 2");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("tables", () => {
+    it("preserves table content and applies formatting", () => {
+      const markdown = [
+        "| Header 1 | Header 2 |",
+        "|----------|----------|",
+        "| Cell 1   | Cell 2   |"
+      ].join("\n");
+      
+      const result = renderMarkdown(markdown);
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Header 1");
+      expect(stripped).toContain("Header 2");
+      expect(stripped).toContain("Cell 1");
+      expect(stripped).toContain("Cell 2");
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles tables with emojis and multi-width characters", () => {
+      const markdown = [
+        "| Feature | Status |",
+        "|---------|--------|",
+        "| Test    | ✅     |"
+      ].join("\n");
+      
+      const result = renderMarkdown(markdown);
+      const stripped = stripAnsi(result);
+      expect(stripped).toContain("Feature");
+      expect(stripped).toContain("Status");
+      expect(stripped).toContain("Test");
+      expect(stripped).toContain("✅");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("horizontal rules", () => {
+    it("renders horizontal rules with formatting", () => {
+      const result = renderMarkdown("---");
+      expect(hasFormatting(result)).toBe(true);
+      // Should contain some kind of line character
+      expect(stripAnsi(result)).toMatch(/[-─]/);
+    });
+  });
+
+  describe("complex content", () => {
+    it("handles mixed content types", () => {
+      const markdown = [
+        "# Title",
+        "",
+        "Some **bold** text with `code`.",
+        "",
+        "- List item",
+        "",
+        "> Quote",
+        "",
+        "| Table | Header |",
+        "|-------|--------|",
+        "| Cell  | Data   |"
+      ].join("\n");
+      
+      const result = renderMarkdown(markdown);
+      const stripped = stripAnsi(result);
+      
+      // Check all content is preserved
+      expect(stripped).toContain("Title");
+      expect(stripped).toContain("bold");
+      expect(stripped).toContain("code");
+      expect(stripped).toContain("List item");
+      expect(stripped).toContain("Quote");
+      expect(stripped).toContain("Table");
+      expect(stripped).toContain("Cell");
+      
+      // Check formatting is applied
+      expect(hasFormatting(result)).toBe(true);
+    });
+
+    it("handles nested content in lists", () => {
+      const markdown = [
+        "1. First item:",
+        "   ```bash",
+        "   npm install",
+        "   ```",
+        "",
+        "2. Second item:",
+        "   - Nested list",
+        "   - Another item"
+      ].join("\n");
+      
+      const result = renderMarkdown(markdown);
+      const stripped = stripAnsi(result);
+      
+      expect(stripped).toContain("First item");
+      expect(stripped).toContain("npm install");
+      expect(stripped).toContain("Second item");
+      expect(stripped).toContain("Nested list");
+      expect(stripped).toContain("Another item");
+      expect(hasFormatting(result)).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty input", () => {
+      const result = renderMarkdown("");
+      expect(result).toBe("");
+    });
+
+    it("handles whitespace-only input", () => {
+      const result = renderMarkdown("   \n   ");
+      expect(stripAnsi(result).trim()).toBe("");
+    });
+
+    it("preserves special characters", () => {
+      const result = renderMarkdown("Special chars: & < > \" '");
+      expect(stripAnsi(result)).toContain("Special chars: & < > \" '");
+    });
+  });
+});

--- a/source/markdown.ts
+++ b/source/markdown.ts
@@ -1,0 +1,308 @@
+import { marked, MarkedToken, Token, Tokens } from "marked";
+import chalk from "chalk";
+import stringWidth from "string-width";
+
+export function renderMarkdown(markdown: string): string {
+  const tokens = marked.lexer(markdown);
+  return renderTokens(tokens);
+}
+
+function renderTokens(tokens: Token[]): string {
+  return tokens.map(renderToken).join("");
+}
+
+function renderToken(token: Token): string {
+  if (!isMarkedToken(token)) {
+    return renderGeneric(token);
+  }
+
+  switch (token.type) {
+    case "blockquote":
+      return renderBlockquote(token);
+    case "br":
+      return renderBr();
+    case "code":
+      return renderCode(token);
+    case "codespan":
+      return renderCodespan(token);
+    case "def":
+      return renderDef(token);
+    case "del":
+      return renderDel(token);
+    case "em":
+      return renderEm(token);
+    case "escape":
+      return renderEscape(token);
+    case "heading":
+      return renderHeading(token);
+    case "hr":
+      return renderHr();
+    case "html":
+      return renderHtml(token);
+    case "image":
+      return renderImage(token);
+    case "link":
+      return renderLink(token);
+    case "list":
+      return renderList(token);
+    case "list_item":
+      return renderListItem(token);
+    case "paragraph":
+      return renderParagraph(token);
+    case "strong":
+      return renderStrong(token);
+    case "table":
+      return renderTable(token);
+    case "text":
+      return renderText(token);
+    case "space":
+      return renderSpace();
+    default:
+      return renderGeneric(token);
+  }
+}
+
+function renderBlockquote(token: Tokens.Blockquote): string {
+  const content = renderTokens(token.tokens);
+  return content
+    .split("\n")
+    .map(line => {
+      // For nested blockquotes, ensure proper spacing
+      const cleanLine = line.replace(/^\s*/, ''); // Remove leading whitespace for consistent formatting
+      return chalk.italic(`│ ${cleanLine}`);
+    })
+    .join("\n") + "\n";
+}
+
+function renderBr(): string {
+  return "\n";
+}
+
+function renderCode(token: Tokens.Code): string {
+  const lines = token.text.split('\n');
+  const styledLines = lines.map(line => `  ${chalk.white(line)}`);
+  const codeText = styledLines.join('\n');
+
+  if (token.lang || token.codeBlockStyle !== "indented") {
+    const langTag = token.lang ? chalk.dim(`┌─ ${token.lang} `) + chalk.dim('─'.repeat(Math.max(0, 40 - token.lang.length))) : chalk.dim('┌' + '─'.repeat(42));
+    const footer = chalk.dim('└' + '─'.repeat(42));
+    return `${langTag}\n${codeText}\n${footer}\n\n`;
+  }
+
+  return `${codeText}\n\n`;
+}
+
+function renderCodespan(token: Tokens.Codespan): string {
+  return chalk.inverse(` ${token.text} `);
+}
+
+function renderDef(token: Tokens.Def): string {
+  // Don't render definition links which are usually referenced elsewhere.
+  return "";
+}
+
+function renderDel(token: Tokens.Del): string {
+  return chalk.strikethrough.dim(renderTokens(token.tokens));
+}
+
+function renderEm(token: Tokens.Em): string {
+  return chalk.italic(renderTokens(token.tokens));
+}
+
+function renderEscape(token: Tokens.Escape): string {
+  return token.text;
+}
+
+function renderHeading(token: Tokens.Heading): string {
+  const content = renderTokens(token.tokens);
+  const indent = "  ".repeat(Math.max(0, token.depth - 1));
+
+  const colors = [
+    chalk.magenta.bold,
+    chalk.blue.bold,
+    chalk.cyan.bold,
+    chalk.green.bold,
+    chalk.yellow.bold,
+    chalk.red.bold
+  ];
+
+  const colorFn = colors[Math.min(token.depth - 1, colors.length - 1)];
+  const marker = token.depth === 1 ? "█" : token.depth === 2 ? "▆" : "▉";
+
+  return `\n${indent}${colorFn(`${marker} ${content.trim()}`)}\n\n`;
+}
+
+function renderHr(): string {
+  const width = Math.min(process.stdout.columns || 80, 80);
+  return "\n" + chalk.dim("─".repeat(width)) + "\n\n";
+}
+
+function renderHtml(token: Tokens.HTML | Tokens.Tag): string {
+  return token.text;
+}
+
+function renderImage(token: Tokens.Image): string {
+  return chalk.yellow(`[Image: ${token.text}]`);
+}
+
+function renderLink(token: Tokens.Link): string {
+  const content = renderTokens(token.tokens);
+  return `${chalk.blue.underline(content)} ${chalk.dim.cyan(`(${token.href})`)}`;;
+}
+
+function renderList(token: Tokens.List): string {
+  return token.items.map((item, index) => {
+    let prefix = chalk.cyan("• ");
+    if (token.ordered) {
+      const num = (typeof token.start === "number" ? token.start : 1) + index;
+      prefix = chalk.cyan(`${num}. `);
+    }
+    const itemContent = renderListItem(item);
+    return "  " + prefix + itemContent + "\n";
+  }).join("") + "\n";
+}
+
+function renderListItem(token: Tokens.ListItem): string {
+  const renderedTokens = token.tokens.map((childToken, index) => {
+    const rendered = renderToken(childToken);
+    
+    // For nested lists, code blocks, and blockquotes, add proper indentation
+    if (childToken.type === 'list' || childToken.type === 'code' || childToken.type === 'blockquote') {
+      // Add indentation to align with list content (after the bullet point)
+      const indented = rendered.split('\n').map((line, lineIndex) => {
+        return line ? `    ${line}` : line; // Indent all lines including first
+      }).join('\n');
+      
+      // Add newline before nested content if there's preceding content
+      if (index > 0) {
+        return '\n' + indented;
+      }
+      return indented;
+    }
+    
+    // For paragraphs in list items, reduce double newlines to single
+    if (childToken.type === 'paragraph') {
+      // If this paragraph is followed by nested content, ensure it ends with single newline
+      if (index < token.tokens.length - 1) {
+        const nextToken = token.tokens[index + 1];
+        if (nextToken.type === 'list' || nextToken.type === 'code' || nextToken.type === 'blockquote') {
+          return rendered.replace(/\n\n$/, '\n').replace(/\n$/, '');
+        }
+        return rendered.replace(/\n\n$/, '\n');
+      }
+      return rendered.replace(/\n\n$/, '');
+    }
+    
+    return rendered;
+  });
+  
+  let content = renderedTokens.join('').trim();
+  
+  if (token.task && typeof token.checked === "boolean") {
+    const checkbox = token.checked ? chalk.green("[✓]") : chalk.dim("[ ]");
+    content = `${checkbox} ${content}`;
+  }
+  
+  return content;
+}
+
+function renderParagraph(token: Tokens.Paragraph): string {
+  const content = renderTokens(token.tokens);
+  return content.trim() + "\n\n";
+}
+
+function renderStrong(token: Tokens.Strong): string {
+  return chalk.bold(renderTokens(token.tokens));
+}
+
+function renderTable(token: Tokens.Table): string {
+  // Calculate column widths by measuring display width of all content
+  const allRows = [token.header, ...token.rows];
+  const columnWidths = token.header.map((_, colIndex) => {
+    const maxWidth = Math.max(
+      ...allRows.map(row => {
+        const cell = row[colIndex];
+        if (cell) {
+          const content = renderTableCell(cell);
+          // Strip ANSI codes first, then measure display width
+          const plainContent = content.replace(/\u001b\[[0-9;]*m/g, '');
+          return stringWidth(plainContent);
+        }
+        return 0;
+      })
+    );
+    return Math.max(maxWidth, 3); // Minimum width of 3
+  });
+
+  const headerRow = renderTableRow(token.header, columnWidths, true);
+  const separator = chalk.dim("├" + columnWidths.map(w => "─".repeat(w + 2)).join("┼") + "┤\n");
+  const rows = token.rows.map(row => renderTableRow(row, columnWidths, false));
+  return "\n" + headerRow + separator + rows.join("") + "\n";
+}
+
+function renderTableRow(cells: Tokens.TableCell[], columnWidths: number[], isHeader: boolean = false): string {
+  const cellContents = cells.map((cell, index) => {
+    const content = renderTableCell(cell);
+    const plainContent = content.replace(/\u001b\[[0-9;]*m/g, '');
+    const displayWidth = stringWidth(plainContent);
+    const padding = " ".repeat(Math.max(0, columnWidths[index] - displayWidth));
+    const styledContent = isHeader ? chalk.bold.cyan(content) : content;
+    return styledContent + padding;
+  });
+  const border = chalk.dim("│");
+  return `${border} ${cellContents.join(` ${border} `)} ${border}\n`;
+}
+
+function renderTableCell(token: Tokens.TableCell): string {
+  return renderTokens(token.tokens);
+}
+
+function renderText(token: Tokens.Text): string {
+  if (token.tokens) {
+    return renderTokens(token.tokens);
+  }
+  return token.text;
+}
+
+function renderSpace(): string {
+  return "";
+}
+
+function renderGeneric(token: Tokens.Generic): string {
+  if (token.tokens) {
+    return renderTokens(token.tokens);
+  }
+  return token.raw || "";
+}
+
+const MARKED_TOKEN_TYPES = [
+  "blockquote",
+  "br",
+  "code",
+  "codespan",
+  "def",
+  "del",
+  "em",
+  "escape",
+  "heading",
+  "hr",
+  "html",
+  "image",
+  "link",
+  "list",
+  "list_item",
+  "paragraph",
+  "space",
+  "strong",
+  "table",
+  "text",
+];
+
+/**
+ * Marked provides a `Tokens.Generic` interface with a string type for extensions, which breaks
+ * type narrowing for `Token`, so we check that the token is not generic (ie. a `MarkedToken`) here.
+ * https://github.com/markedjs/marked/issues/2938
+ */
+function isMarkedToken(token: Token): token is MarkedToken {
+  return MARKED_TOKEN_TYPES.includes(token.type);
+}


### PR DESCRIPTION
As described. Spent a bunch of time cleaning up corner cases and little bugs.

Looks pretty decent in my color scheme. Also checked that it looked sane and decent in a couple other schemes in iterm2.

Uses `string-width` to get visual width of characters for table column rendering.

Interesting enough, in support of octofriend, this was one of the few cases where octo was definitively better than Claude Code from scratch. However it still struggled with subsequent direction (high token costs, long output delays, subpar output), at least with GLM-4.5.

My methodology ended up generating the initial code with octo/GLM-4.5 and using Claude Code to fine tune the little UI nits and improve aesthetics.

Demo script (also tested with some queries in octo itself):

<img width="1822" height="1690" alt="CleanShot 2025-08-19 at 23 11 18@2x" src="https://github.com/user-attachments/assets/64611e97-0953-4e7e-8025-0be6efa4070c" />
<img width="1818" height="1386" alt="CleanShot 2025-08-19 at 23 11 25@2x" src="https://github.com/user-attachments/assets/09d94816-5896-4496-bc2d-2e4eb2c739db" />
<img width="1830" height="1238" alt="CleanShot 2025-08-19 at 23 11 30@2x" src="https://github.com/user-attachments/assets/c41481d4-7dbd-4d20-a89d-b943a511ab88" />
<img width="1804" height="1510" alt="CleanShot 2025-08-19 at 23 11 37@2x" src="https://github.com/user-attachments/assets/c298ed4d-4f0e-410c-bc7d-31b77017daa3" />
