### PR TITLE
feat: allow both 'args' and 'arguments' in MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 /training/fast-apply/unfat/output
 /training/fix-json/unfat/output
+
+.idea

--- a/source/config.ts
+++ b/source/config.ts
@@ -17,6 +17,7 @@ const KeyConfigSchema = t.dict(t.str);
 const McpServerConfigSchema = t.exact({
   command: t.str,
   args: t.optional(t.array(t.str)),
+  arguments: t.optional(t.array(t.str)),
 });
 
 const ConfigSchema = t.exact({

--- a/source/tools/tool-defs/mcp.ts
+++ b/source/tools/tool-defs/mcp.ts
@@ -78,6 +78,10 @@ export async function connectMcpServer(
     throw new ToolError(`MCP server "${serverName}" not found in config. Please add it to mcpServers.`);
   }
 
+  if (serverConfig.args && serverConfig.arguments) {
+    throw new ToolError(`MCP server "${serverName}" cannot have both "args" and "arguments" fields defined. Please use only one of them.`);
+  }
+
   const client = new Client({
     name: `octofriend-${serverName}`,
     version: "1.0.0",
@@ -85,7 +89,7 @@ export async function connectMcpServer(
 
   const transport = new StdioClientTransport({
     command: serverConfig.command,
-    args: serverConfig.args || [],
+    args: serverConfig.args || serverConfig.arguments || [],
     stderr: log ? "inherit" : "ignore",
   });
 


### PR DESCRIPTION
- Add support for both 'args' and 'arguments' fields in McpServerConfig
- Add validation to prevent using both fields simultaneously
- Update MCP tool handling to use either format
- Add .idea to .gitignore