### PR TITLE
Use bash from PATH instead of /bin/bash

### DIFF
--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -63,7 +63,7 @@ export class LocalTransport implements Transport {
     return new Promise<string>((resolve, reject) => {
       const child = spawn(cmd, {
         cwd: process.cwd(),
-        shell: "/bin/bash",
+        shell: "bash",
         timeout,
         stdio: ['ignore', 'pipe', 'pipe']
       });


### PR DESCRIPTION
Octo currently breaks on some Linux distros that don't use [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) or don't ship with Bash (e.g., NixOS, Alpine):

```
▶  hi

CommandFailedError: Command failed: spawn /bin/bash ENOENT
    at ChildProcess.<anonymous> (file:///nix/store/mb0sd6xjb9bkksnbhf82f1lmll6rdcwa-octofriend-0.0.36/lib/node_modules/octofriend/dist/source/transports/local.js:115:24)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
Request failed. Retrying...
```

To fix this, Octo should be using `bash` from user `$PATH` instead of hard-coding `/bin/bash`. This would also improve compatibility with macOS where `/bin/bash` is very old (3.2.57) and people usually install Bash via Homebrew or other package managers (which may be located in `/usr/local/bin/bash` or `/opt/local/bin/bash`).