### PR TITLE
Add environment variable support to mcpServers config

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -17,6 +17,7 @@ const KeyConfigSchema = t.dict(t.str);
 const McpServerConfigSchema = t.exact({
   command: t.str,
   args: t.optional(t.array(t.str)),
+  env: t.optional(t.dict(t.str)),
 });
 
 const ConfigSchema = t.exact({

--- a/source/tools/tool-defs/mcp.ts
+++ b/source/tools/tool-defs/mcp.ts
@@ -83,9 +83,20 @@ export async function connectMcpServer(
     version: "1.0.0",
   });
 
+  const baseEnvEntries = Object.entries(process.env).filter(
+    (entry): entry is [string, string] => entry[1] != null,
+  );
+
+  const baseEnv: Record<string, string> = Object.fromEntries(baseEnvEntries);
+
+  const env: Record<string, string> = serverConfig.env
+    ? { ...baseEnv, ...serverConfig.env }
+    : baseEnv;
+
   const transport = new StdioClientTransport({
     command: serverConfig.command,
     args: serverConfig.args || [],
+    env,
     stderr: log ? "inherit" : "ignore",
   });
 


### PR DESCRIPTION
Allow the user to configure mcp servers that require environment variables, without polluting their local environment:

```
braveSearch: {
      command: "npx",
      args: [ "-y", "@modelcontextprotocol/server-brave-search"],
      env: {
        "BRAVE_API_KEY": "<apikey>"
      }
    }
```