### PR TITLE
Set required bun version in package.json, and verify during build.

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -24,6 +24,19 @@ import { reactCompiler } from "bun-plugin-react-compiler";
 
 const root = import.meta.dir;
 
+const enginesBun: unknown = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"))
+  .engines?.bun;
+if (typeof enginesBun !== "string") {
+  console.error("package.json is missing engines.bun");
+  process.exit(1);
+}
+if (!Bun.semver.satisfies(Bun.version, enginesBun)) {
+  console.error(
+    `octofriend requires Bun ${enginesBun} (found ${Bun.version}); run \`bun upgrade\``,
+  );
+  process.exit(1);
+}
+
 type Target = {
   /** Output directory: `dist/<name>/` */
   name: string;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "type": "module",
   "preferGlobal": true,
+  "engines": {
+    "bun": ">=1.4.0"
+  },
   "scripts": {
     "dev": "bun --watch source/cli/cli.tsx",
     "exec": "bun source/cli/cli.tsx",


### PR DESCRIPTION
Small proposal to set and verify required bun version, as I ran into a confusing error [1] until I realized it was because I didn't update bun yet :P

[1]
```bash
$ bun build.ts
Building dist/linux-x64/octo (bun-linux-x64)...
3 | function readMigrationFiles(config) {
4 |   const migrationFolderTo = config.migrationsFolder;
5 |   const migrationQueries = [];
6 |   const journalPath = `${migrationFolderTo}/meta/_journal.json`;
7 |   if (!fs.existsSync(journalPath)) {
8 |     throw new Error(`Can't find meta/_journal.json file`);
                  ^
error: Can't find meta/_journal.json file
      at fxH (node_modules/drizzle-orm/migrator.js:8:15)
      at DxH (node_modules/drizzle-orm/bun-sqlite/migrator.js:3:22)
      at txH (source/db/migrate.ts:14:3)
      at <anonymous> (source/cli/cli.tsx:655:1)
```