### PR TITLE
Add background-process and manage-background-process tools

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -2244,7 +2244,7 @@ function BackgroundProcessToolRenderer({
 }: {
   item: ParsedToolSchemaFrom<typeof backgroundProcess>;
 }) {
-  return <ToolCallRow name={item.name}>{item.arguments.cmd}</ToolCallRow>;
+  return <ToolCallRow name={item.name}>{item.arguments.label ?? item.arguments.cmd}</ToolCallRow>;
 }
 
 function ManageBackgroundProcessToolRenderer({
@@ -2254,9 +2254,9 @@ function ManageBackgroundProcessToolRenderer({
 }) {
   return (
     <ToolCallRow name={item.name}>
-      {item.arguments.id == null
+      {item.arguments.label == null
         ? item.arguments.action
-        : `${item.arguments.action} ${item.arguments.id}`}
+        : `${item.arguments.action} ${item.arguments.label}`}
     </ToolCallRow>
   );
 }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -50,6 +50,8 @@ import skill from "./tools/tool-defs/skill.ts";
 import webSearch from "./tools/tool-defs/web-search.ts";
 import glob from "./tools/tool-defs/glob.ts";
 import grep from "./tools/tool-defs/grep.ts";
+import backgroundProcess from "./tools/tool-defs/background-process.ts";
+import manageBackgroundProcess from "./tools/tool-defs/manage-background-process.ts";
 import { ALWAYS_REQUEST_PERMISSION_TOOLS, SKIP_CONFIRMATION_TOOLS } from "./tools/index.ts";
 import { ParsedSchema as EditParsedSchema } from "./tools/tool-defs/edit.ts";
 import { useShallow } from "zustand/react/shallow";
@@ -2084,6 +2086,10 @@ function ToolMessageRenderer({ item }: { item: ToolCallRequest | MalformedToolRe
       return <ListToolRenderer item={parsedToolSchema(item)} />;
     case "shell":
       return <ShellToolRenderer item={parsedToolSchema(item)} />;
+    case "background-process":
+      return <BackgroundProcessToolRenderer item={parsedToolSchema(item)} />;
+    case "manage-background-process":
+      return <ManageBackgroundProcessToolRenderer item={parsedToolSchema(item)} />;
     case "edit":
       return <EditToolRenderer item={parsedToolSchema(item)} />;
     case "create":
@@ -2232,6 +2238,29 @@ function ShellToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof shell> 
     </TerminalFlex>
   );
 }
+
+function BackgroundProcessToolRenderer({
+  item,
+}: {
+  item: ParsedToolSchemaFrom<typeof backgroundProcess>;
+}) {
+  return <ToolCallRow name={item.name}>{item.arguments.cmd}</ToolCallRow>;
+}
+
+function ManageBackgroundProcessToolRenderer({
+  item,
+}: {
+  item: ParsedToolSchemaFrom<typeof manageBackgroundProcess>;
+}) {
+  return (
+    <ToolCallRow name={item.name}>
+      {item.arguments.id == null
+        ? item.arguments.action
+        : `${item.arguments.action} ${item.arguments.id}`}
+    </ToolCallRow>
+  );
+}
+
 function ReadToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof read> }) {
   return <ToolCallRow name={item.name}>{item.arguments.filePath}</ToolCallRow>;
 }

--- a/source/background-process.test.ts
+++ b/source/background-process.test.ts
@@ -5,7 +5,7 @@ import { BackgroundProcessManager } from "./background-process.ts";
 describe("BackgroundProcessManager.start", () => {
   it("runs the command and polls report the exit", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("echo hello");
+    const backgroundProcess = manager.start("echo hello", "hello");
 
     await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
 
@@ -18,7 +18,7 @@ describe("BackgroundProcessManager.start", () => {
 
   it("polls drain output incrementally", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("echo hello");
+    const backgroundProcess = manager.start("echo hello", "hello");
 
     let drained = "";
     await waitFor(() => {
@@ -32,11 +32,12 @@ describe("BackgroundProcessManager.start", () => {
     expect(backgroundProcess.outputExceeded).toBe(false);
   });
 
-  it("reports the command the process was started with", async () => {
+  it("reports the command and label the process was started with", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("echo hello");
+    const backgroundProcess = manager.start("echo hello", "hello");
 
     expect(manager.poll(backgroundProcess.id)!.command).toBe("echo hello");
+    expect(manager.poll(backgroundProcess.id)!.label).toBe("hello");
 
     await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
   });
@@ -45,7 +46,7 @@ describe("BackgroundProcessManager.start", () => {
 describe("BackgroundProcessManager.kill", () => {
   it("terminates a long-running process", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("sleep 30");
+    const backgroundProcess = manager.start("sleep 30", "sleeper");
     expect(manager.poll(backgroundProcess.id)!.status).toEqual({ state: "running" });
 
     expect(await manager.kill(backgroundProcess.id)).toBe(backgroundProcess);
@@ -56,7 +57,7 @@ describe("BackgroundProcessManager.kill", () => {
 describe("BackgroundProcess.awaitChange", () => {
   it("waits up to the timeout when nothing changes", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("sleep 30");
+    const backgroundProcess = manager.start("sleep 30", "sleeper");
 
     const start = Date.now();
     await backgroundProcess.awaitActivity(250, new AbortController().signal);
@@ -70,7 +71,7 @@ describe("BackgroundProcess.awaitChange", () => {
 
   it("unblocks when output arrives", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("sleep 0.3 && echo late");
+    const backgroundProcess = manager.start("sleep 0.3 && echo late", "late-output");
 
     const start = Date.now();
     await backgroundProcess.awaitActivity(10_000, new AbortController().signal);
@@ -84,7 +85,7 @@ describe("BackgroundProcess.awaitChange", () => {
 
   it("unblocks when the process exits", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("sleep 0.3");
+    const backgroundProcess = manager.start("sleep 0.3", "short-sleep");
 
     const start = Date.now();
     await backgroundProcess.awaitActivity(10_000, new AbortController().signal);
@@ -96,7 +97,7 @@ describe("BackgroundProcess.awaitChange", () => {
 
   it("unblocks on abort", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const backgroundProcess = manager.start("sleep 30");
+    const backgroundProcess = manager.start("sleep 30", "sleeper");
     const controller = new AbortController();
     setTimeout(() => controller.abort(), 50);
 
@@ -111,16 +112,23 @@ describe("BackgroundProcess.awaitChange", () => {
 });
 
 describe("BackgroundProcessManager.list", () => {
-  it("lists started processes with their ids, commands, and statuses", async () => {
+  it("lists started processes with their ids, labels, commands, and statuses", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
-    const first = manager.start("echo hello");
-    const second = manager.start("sleep 30");
+    const first = manager.start("echo hello", "hello");
+    const second = manager.start("sleep 30", "sleeper");
 
     await waitFor(() => manager.poll(first.id)?.status.state === "exited");
 
-    expect(manager.list().map(p => ({ id: p.id, command: p.command, status: p.status }))).toEqual([
-      { id: first.id, command: "echo hello", status: { state: "exited", code: 0, signal: null } },
-      { id: second.id, command: "sleep 30", status: { state: "running" } },
+    expect(
+      manager.list().map(p => ({ id: p.id, label: p.label, command: p.command, status: p.status })),
+    ).toEqual([
+      {
+        id: first.id,
+        label: "hello",
+        command: "echo hello",
+        status: { state: "exited", code: 0, signal: null },
+      },
+      { id: second.id, label: "sleeper", command: "sleep 30", status: { state: "running" } },
     ]);
 
     await manager.kill(second.id);
@@ -137,8 +145,8 @@ describe("BackgroundProcessManager unknown ids", () => {
   it("returns null from poll and kill", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
 
-    expect(manager.poll("bg-1")).toBeNull();
-    expect(await manager.kill("bg-1")).toBeNull();
+    expect(manager.poll("bg-process-1")).toBeNull();
+    expect(await manager.kill("bg-process-1")).toBeNull();
   });
 });
 

--- a/source/background-process.test.ts
+++ b/source/background-process.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import { OctoProcessManager } from "./octo-process.ts";
+import { BackgroundProcessManager } from "./background-process.ts";
+
+describe("BackgroundProcessManager.start", () => {
+  it("runs the command and polls report the exit", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("echo hello");
+
+    await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
+
+    expect(manager.poll(backgroundProcess.id)!.status).toEqual({
+      state: "exited",
+      code: 0,
+      signal: null,
+    });
+  });
+
+  it("polls drain output incrementally", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("echo hello");
+
+    let drained = "";
+    await waitFor(() => {
+      drained += manager.poll(backgroundProcess.id)!.drainUnreadOutput();
+      return drained === "hello\n";
+    });
+
+    await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
+
+    expect(manager.poll(backgroundProcess.id)!.drainUnreadOutput()).toBe("");
+    expect(backgroundProcess.outputExceeded).toBe(false);
+  });
+
+  it("reports the command the process was started with", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("echo hello");
+
+    expect(manager.poll(backgroundProcess.id)!.command).toBe("echo hello");
+
+    await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
+  });
+});
+
+describe("BackgroundProcessManager.kill", () => {
+  it("terminates a long-running process", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("sleep 30");
+    expect(manager.poll(backgroundProcess.id)!.status).toEqual({ state: "running" });
+
+    expect(manager.kill(backgroundProcess.id)).toBe(backgroundProcess);
+
+    await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
+  });
+});
+
+describe("BackgroundProcess.awaitChange", () => {
+  it("waits up to the timeout when nothing changes", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("sleep 30");
+
+    const start = Date.now();
+    await backgroundProcess.awaitActivity(250, new AbortController().signal);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+    expect(backgroundProcess.drainUnreadOutput()).toBe("");
+
+    manager.kill(backgroundProcess.id);
+    await waitFor(() => backgroundProcess.status.state === "exited");
+  });
+
+  it("unblocks when output arrives", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("sleep 0.3 && echo late");
+
+    const start = Date.now();
+    await backgroundProcess.awaitActivity(10_000, new AbortController().signal);
+    const elapsed = Date.now() - start;
+
+    expect(backgroundProcess.drainUnreadOutput()).toContain("late");
+    expect(elapsed).toBeLessThan(5_000);
+
+    await waitFor(() => backgroundProcess.status.state === "exited");
+  });
+
+  it("unblocks when the process exits", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("sleep 0.3");
+
+    const start = Date.now();
+    await backgroundProcess.awaitActivity(10_000, new AbortController().signal);
+    const elapsed = Date.now() - start;
+
+    expect(backgroundProcess.status.state).toBe("exited");
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("unblocks on abort", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("sleep 30");
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 50);
+
+    const start = Date.now();
+    await backgroundProcess.awaitActivity(10_000, controller.signal);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(5_000);
+
+    manager.kill(backgroundProcess.id);
+    await waitFor(() => backgroundProcess.status.state === "exited");
+  });
+});
+
+describe("BackgroundProcessManager.list", () => {
+  it("lists started processes with their ids, commands, and statuses", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const first = manager.start("echo hello");
+    const second = manager.start("sleep 30");
+
+    await waitFor(() => manager.poll(first.id)?.status.state === "exited");
+
+    expect(manager.list().map(p => ({ id: p.id, command: p.command, status: p.status }))).toEqual([
+      { id: first.id, command: "echo hello", status: { state: "exited", code: 0, signal: null } },
+      { id: second.id, command: "sleep 30", status: { state: "running" } },
+    ]);
+
+    manager.kill(second.id);
+    await waitFor(() => manager.poll(second.id)?.status.state === "exited");
+  });
+
+  it("is empty before any process is started", () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+
+    expect(manager.list()).toEqual([]);
+  });
+});
+
+describe("BackgroundProcessManager unknown ids", () => {
+  it("returns null from poll and kill", () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+
+    expect(manager.poll("bg-1")).toBeNull();
+    expect(manager.kill("bg-1")).toBeNull();
+  });
+});
+
+async function waitFor(cond: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("Timed out waiting for condition");
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+}

--- a/source/background-process.test.ts
+++ b/source/background-process.test.ts
@@ -22,14 +22,40 @@ describe("BackgroundProcessManager.start", () => {
 
     let drained = "";
     await waitFor(() => {
-      drained += manager.poll(backgroundProcess.id)!.drainUnreadOutput();
+      drained += manager.poll(backgroundProcess.id)!.drainUnreadOutput().stdout;
       return drained === "hello\n";
     });
 
     await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
 
-    expect(manager.poll(backgroundProcess.id)!.drainUnreadOutput()).toBe("");
+    expect(manager.poll(backgroundProcess.id)!.drainUnreadOutput()).toEqual({
+      stdout: "",
+      stderr: "",
+    });
     expect(backgroundProcess.outputExceeded).toBe(false);
+  });
+
+  it("keeps stdout and stderr separate", async () => {
+    const manager = new BackgroundProcessManager(new OctoProcessManager());
+    const backgroundProcess = manager.start("echo out && echo err >&2", "both-streams");
+
+    let stdout = "";
+    let stderr = "";
+    await waitFor(() => {
+      const drained = manager.poll(backgroundProcess.id)!.drainUnreadOutput();
+      stdout += drained.stdout;
+      stderr += drained.stderr;
+      return stdout.includes("out") && stderr.includes("err");
+    });
+
+    await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
+
+    expect(stdout).toBe("out\n");
+    expect(stderr).toBe("err\n");
+    expect(manager.poll(backgroundProcess.id)!.drainUnreadOutput()).toEqual({
+      stdout: "",
+      stderr: "",
+    });
   });
 
   it("reports the command and label the process was started with", async () => {
@@ -64,7 +90,7 @@ describe("BackgroundProcess.awaitChange", () => {
     const elapsed = Date.now() - start;
 
     expect(elapsed).toBeGreaterThanOrEqual(200);
-    expect(backgroundProcess.drainUnreadOutput()).toBe("");
+    expect(backgroundProcess.drainUnreadOutput()).toEqual({ stdout: "", stderr: "" });
 
     await manager.kill(backgroundProcess.id);
   });
@@ -77,7 +103,7 @@ describe("BackgroundProcess.awaitChange", () => {
     await backgroundProcess.awaitActivity(10_000, new AbortController().signal);
     const elapsed = Date.now() - start;
 
-    expect(backgroundProcess.drainUnreadOutput()).toContain("late");
+    expect(backgroundProcess.drainUnreadOutput().stdout).toContain("late");
     expect(elapsed).toBeLessThan(5_000);
 
     await waitFor(() => backgroundProcess.status.state === "exited");

--- a/source/background-process.test.ts
+++ b/source/background-process.test.ts
@@ -48,9 +48,8 @@ describe("BackgroundProcessManager.kill", () => {
     const backgroundProcess = manager.start("sleep 30");
     expect(manager.poll(backgroundProcess.id)!.status).toEqual({ state: "running" });
 
-    expect(manager.kill(backgroundProcess.id)).toBe(backgroundProcess);
-
-    await waitFor(() => manager.poll(backgroundProcess.id)?.status.state === "exited");
+    expect(await manager.kill(backgroundProcess.id)).toBe(backgroundProcess);
+    expect(backgroundProcess.status.state).toBe("exited");
   });
 });
 
@@ -66,8 +65,7 @@ describe("BackgroundProcess.awaitChange", () => {
     expect(elapsed).toBeGreaterThanOrEqual(200);
     expect(backgroundProcess.drainUnreadOutput()).toBe("");
 
-    manager.kill(backgroundProcess.id);
-    await waitFor(() => backgroundProcess.status.state === "exited");
+    await manager.kill(backgroundProcess.id);
   });
 
   it("unblocks when output arrives", async () => {
@@ -108,8 +106,7 @@ describe("BackgroundProcess.awaitChange", () => {
 
     expect(elapsed).toBeLessThan(5_000);
 
-    manager.kill(backgroundProcess.id);
-    await waitFor(() => backgroundProcess.status.state === "exited");
+    await manager.kill(backgroundProcess.id);
   });
 });
 
@@ -126,8 +123,7 @@ describe("BackgroundProcessManager.list", () => {
       { id: second.id, command: "sleep 30", status: { state: "running" } },
     ]);
 
-    manager.kill(second.id);
-    await waitFor(() => manager.poll(second.id)?.status.state === "exited");
+    await manager.kill(second.id);
   });
 
   it("is empty before any process is started", () => {
@@ -138,11 +134,11 @@ describe("BackgroundProcessManager.list", () => {
 });
 
 describe("BackgroundProcessManager unknown ids", () => {
-  it("returns null from poll and kill", () => {
+  it("returns null from poll and kill", async () => {
     const manager = new BackgroundProcessManager(new OctoProcessManager());
 
     expect(manager.poll("bg-1")).toBeNull();
-    expect(manager.kill("bg-1")).toBeNull();
+    expect(await manager.kill("bg-1")).toBeNull();
   });
 });
 

--- a/source/background-process.ts
+++ b/source/background-process.ts
@@ -23,6 +23,7 @@ export class BackgroundProcess {
   private _outputExceeded = false;
   private _status: BackgroundProcessStatus = { state: "running" };
   private readonly activityListeners = new Set<() => void>();
+  private readonly processClosedPromise: Promise<void>;
 
   constructor(id: string, octoProcess: OctoProcess, command: string) {
     if (octoProcess.stdout == null || octoProcess.stderr == null) {
@@ -31,6 +32,7 @@ export class BackgroundProcess {
     this.id = id;
     this.octoProcess = octoProcess;
     this.command = command;
+    this.processClosedPromise = new Promise(resolve => octoProcess.once("close", () => resolve()));
 
     octoProcess.stdout.on("data", data => this.appendOutput(data));
     octoProcess.stderr.on("data", data => this.appendOutput(data));
@@ -54,8 +56,9 @@ export class BackgroundProcess {
     return this._outputExceeded;
   }
 
-  kill(): void {
+  async kill(): Promise<void> {
     this.octoProcess.terminate({ graceMs: KILL_GRACE_MS });
+    await this.processClosedPromise;
   }
 
   get hasUnreadOutput(): boolean {
@@ -91,7 +94,7 @@ export class BackgroundProcess {
     }
     this._outputExceeded = true;
     this.emitActivityNotification();
-    this.kill();
+    void this.kill();
   }
 
   private emitActivityNotification(): void {
@@ -125,10 +128,10 @@ export class BackgroundProcessManager {
     return this.backgroundProcesses.get(id) ?? null;
   }
 
-  kill(id: string): BackgroundProcess | null {
+  async kill(id: string): Promise<BackgroundProcess | null> {
     const backgroundProcess = this.backgroundProcesses.get(id);
     if (backgroundProcess == null) return null;
-    backgroundProcess.kill();
+    await backgroundProcess.kill();
     return backgroundProcess;
   }
 

--- a/source/background-process.ts
+++ b/source/background-process.ts
@@ -11,10 +11,12 @@ export type BackgroundProcessStatus =
       readonly state: "exited";
       readonly code: number | null;
       readonly signal: NodeJS.Signals | null;
+      readonly error?: string;
     };
 
 export class BackgroundProcess {
   readonly id: string;
+  readonly label: string;
   readonly command: string;
 
   private readonly octoProcess: OctoProcess;
@@ -25,11 +27,12 @@ export class BackgroundProcess {
   private readonly activityListeners = new Set<() => void>();
   private readonly processClosedPromise: Promise<void>;
 
-  constructor(id: string, octoProcess: OctoProcess, command: string) {
+  constructor(id: string, label: string, octoProcess: OctoProcess, command: string) {
     if (octoProcess.stdout == null || octoProcess.stderr == null) {
       throw new Error("Background processes must be spawned with piped stdio");
     }
     this.id = id;
+    this.label = label;
     this.octoProcess = octoProcess;
     this.command = command;
     this.processClosedPromise = new Promise(resolve => octoProcess.once("close", () => resolve()));
@@ -43,7 +46,7 @@ export class BackgroundProcess {
     octoProcess.on("error", error => {
       this.appendOutput(`Spawn error: ${error.message}\n`);
       if (this._status.state === "running") {
-        this._status = { state: "exited", code: null, signal: null };
+        this._status = { state: "exited", code: null, signal: null, error: error.message };
       }
     });
   }
@@ -81,7 +84,7 @@ export class BackgroundProcess {
       onActivity = resolve;
     });
     this.activityListeners.add(onActivity);
-    userAbortSignal.addEventListener("abort", onActivity, { once: true });
+    userAbortSignal.addEventListener("abort", onActivity);
     await Promise.race([activityOccurred, sleep(timeoutMs)]);
     userAbortSignal.removeEventListener("abort", onActivity);
     this.activityListeners.delete(onActivity);
@@ -111,15 +114,15 @@ export class BackgroundProcessManager {
 
   constructor(private readonly octoProcessManager: OctoProcessManager) {}
 
-  start(command: string): BackgroundProcess {
-    const id = `bg-${++this.nextId}`;
+  start(command: string, label: string): BackgroundProcess {
+    const id = `bg-process-${++this.nextId}`;
     const octoProcess = this.octoProcessManager.spawn(command, {
       cwd: process.cwd(),
       shell: "bash",
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
     });
-    const backgroundProcess = new BackgroundProcess(id, octoProcess, command);
+    const backgroundProcess = new BackgroundProcess(id, label, octoProcess, command);
     this.backgroundProcesses.set(id, backgroundProcess);
     return backgroundProcess;
   }

--- a/source/background-process.ts
+++ b/source/background-process.ts
@@ -21,7 +21,6 @@ export class BackgroundProcess {
 
   private readonly octoProcess: OctoProcess;
   private readonly output = new ShellOutput();
-  private readOffset = 0;
   private _outputExceeded = false;
   private _status: BackgroundProcessStatus = { state: "running" };
   private readonly activityListeners = new Set<() => void>();
@@ -64,21 +63,16 @@ export class BackgroundProcess {
     await this.processClosedPromise;
   }
 
-  get hasUnreadOutput(): boolean {
-    const buffered = this.output.getOutput();
-    return buffered != null && buffered.length > this.readOffset;
+  get hasUndrainedOutput(): boolean {
+    return this.output.hasUndrainedOutput();
   }
 
   drainUnreadOutput(): string {
-    const buffered = this.output.getOutput();
-    if (buffered == null) return "";
-    const output = buffered.slice(this.readOffset);
-    this.readOffset = buffered.length;
-    return output;
+    return this.output.drainNewOutput();
   }
 
   async awaitActivity(timeoutMs: number, userAbortSignal: AbortSignal): Promise<void> {
-    if (this._status.state === "exited" || this._outputExceeded || this.hasUnreadOutput) return;
+    if (this._status.state === "exited" || this._outputExceeded || this.hasUndrainedOutput) return;
     let onActivity: () => void = () => {};
     const activityOccurred = new Promise<void>(resolve => {
       onActivity = resolve;

--- a/source/background-process.ts
+++ b/source/background-process.ts
@@ -20,7 +20,8 @@ export class BackgroundProcess {
   readonly command: string;
 
   private readonly octoProcess: OctoProcess;
-  private readonly output = new ShellOutput();
+  private readonly stdout = new ShellOutput();
+  private readonly stderr = new ShellOutput();
   private _outputExceeded = false;
   private _status: BackgroundProcessStatus = { state: "running" };
   private readonly activityListeners = new Set<() => void>();
@@ -36,14 +37,14 @@ export class BackgroundProcess {
     this.command = command;
     this.processClosedPromise = new Promise(resolve => octoProcess.once("close", () => resolve()));
 
-    octoProcess.stdout.on("data", data => this.appendOutput(data));
-    octoProcess.stderr.on("data", data => this.appendOutput(data));
+    octoProcess.stdout.on("data", data => this.appendOutput(this.stdout, data));
+    octoProcess.stderr.on("data", data => this.appendOutput(this.stderr, data));
     octoProcess.on("exit", (code, signal) => {
       this._status = { state: "exited", code, signal };
       this.emitActivityNotification();
     });
     octoProcess.on("error", error => {
-      this.appendOutput(`Spawn error: ${error.message}\n`);
+      this.appendOutput(this.stderr, `Spawn error: ${error.message}\n`);
       if (this._status.state === "running") {
         this._status = { state: "exited", code: null, signal: null, error: error.message };
       }
@@ -64,11 +65,14 @@ export class BackgroundProcess {
   }
 
   get hasUndrainedOutput(): boolean {
-    return this.output.hasUndrainedOutput();
+    return this.stdout.hasUndrainedOutput() || this.stderr.hasUndrainedOutput();
   }
 
-  drainUnreadOutput(): string {
-    return this.output.drainNewOutput();
+  drainUnreadOutput(): { stdout: string; stderr: string } {
+    return {
+      stdout: this.stdout.drainNewOutput(),
+      stderr: this.stderr.drainNewOutput(),
+    };
   }
 
   async awaitActivity(timeoutMs: number, userAbortSignal: AbortSignal): Promise<void> {
@@ -84,8 +88,8 @@ export class BackgroundProcess {
     this.activityListeners.delete(onActivity);
   }
 
-  private appendOutput(data: string | Buffer): void {
-    if (this.output.append(data)) {
+  private appendOutput(output: ShellOutput, data: string | Buffer): void {
+    if (output.append(data)) {
       this.emitActivityNotification();
       return;
     }

--- a/source/background-process.ts
+++ b/source/background-process.ts
@@ -1,0 +1,146 @@
+import { registry } from "antipattern";
+import { OctoProcess, OctoProcessManager, processes } from "./octo-process.ts";
+import { sleep } from "./sleep.ts";
+import { ShellOutput } from "./transports/transport-common.ts";
+
+const KILL_GRACE_MS = 1000;
+
+export type BackgroundProcessStatus =
+  | { readonly state: "running" }
+  | {
+      readonly state: "exited";
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    };
+
+export class BackgroundProcess {
+  readonly id: string;
+  readonly command: string;
+
+  private readonly octoProcess: OctoProcess;
+  private readonly output = new ShellOutput();
+  private readOffset = 0;
+  private _outputExceeded = false;
+  private _status: BackgroundProcessStatus = { state: "running" };
+  private readonly activityListeners = new Set<() => void>();
+
+  constructor(id: string, octoProcess: OctoProcess, command: string) {
+    if (octoProcess.stdout == null || octoProcess.stderr == null) {
+      throw new Error("Background processes must be spawned with piped stdio");
+    }
+    this.id = id;
+    this.octoProcess = octoProcess;
+    this.command = command;
+
+    octoProcess.stdout.on("data", data => this.appendOutput(data));
+    octoProcess.stderr.on("data", data => this.appendOutput(data));
+    octoProcess.on("exit", (code, signal) => {
+      this._status = { state: "exited", code, signal };
+      this.emitActivityNotification();
+    });
+    octoProcess.on("error", error => {
+      this.appendOutput(`Spawn error: ${error.message}\n`);
+      if (this._status.state === "running") {
+        this._status = { state: "exited", code: null, signal: null };
+      }
+    });
+  }
+
+  get status(): BackgroundProcessStatus {
+    return this._status;
+  }
+
+  get outputExceeded(): boolean {
+    return this._outputExceeded;
+  }
+
+  kill(): void {
+    this.octoProcess.terminate({ graceMs: KILL_GRACE_MS });
+  }
+
+  get hasUnreadOutput(): boolean {
+    const buffered = this.output.getOutput();
+    return buffered != null && buffered.length > this.readOffset;
+  }
+
+  drainUnreadOutput(): string {
+    const buffered = this.output.getOutput();
+    if (buffered == null) return "";
+    const output = buffered.slice(this.readOffset);
+    this.readOffset = buffered.length;
+    return output;
+  }
+
+  async awaitActivity(timeoutMs: number, userAbortSignal: AbortSignal): Promise<void> {
+    if (this._status.state === "exited" || this._outputExceeded || this.hasUnreadOutput) return;
+    let onActivity: () => void = () => {};
+    const activityOccurred = new Promise<void>(resolve => {
+      onActivity = resolve;
+    });
+    this.activityListeners.add(onActivity);
+    userAbortSignal.addEventListener("abort", onActivity, { once: true });
+    await Promise.race([activityOccurred, sleep(timeoutMs)]);
+    userAbortSignal.removeEventListener("abort", onActivity);
+    this.activityListeners.delete(onActivity);
+  }
+
+  private appendOutput(data: string | Buffer): void {
+    if (this.output.append(data)) {
+      this.emitActivityNotification();
+      return;
+    }
+    this._outputExceeded = true;
+    this.emitActivityNotification();
+    this.kill();
+  }
+
+  private emitActivityNotification(): void {
+    for (const listener of [...this.activityListeners]) {
+      this.activityListeners.delete(listener);
+      listener();
+    }
+  }
+}
+
+export class BackgroundProcessManager {
+  private readonly backgroundProcesses = new Map<string, BackgroundProcess>();
+  private nextId = 0;
+
+  constructor(private readonly octoProcessManager: OctoProcessManager) {}
+
+  start(command: string): BackgroundProcess {
+    const id = `bg-${++this.nextId}`;
+    const octoProcess = this.octoProcessManager.spawn(command, {
+      cwd: process.cwd(),
+      shell: "bash",
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    });
+    const backgroundProcess = new BackgroundProcess(id, octoProcess, command);
+    this.backgroundProcesses.set(id, backgroundProcess);
+    return backgroundProcess;
+  }
+
+  poll(id: string): BackgroundProcess | null {
+    return this.backgroundProcesses.get(id) ?? null;
+  }
+
+  kill(id: string): BackgroundProcess | null {
+    const backgroundProcess = this.backgroundProcesses.get(id);
+    if (backgroundProcess == null) return null;
+    backgroundProcess.kill();
+    return backgroundProcess;
+  }
+
+  list(): BackgroundProcess[] {
+    return [...this.backgroundProcesses.values()];
+  }
+}
+
+const manager = new BackgroundProcessManager(processes.manager());
+
+export const backgroundProcesses = registry({
+  manager: () => {
+    return manager;
+  },
+});

--- a/source/tools/index.ts
+++ b/source/tools/index.ts
@@ -55,7 +55,10 @@ export const SKIP_CONFIRMATION_TOOLS: Array<keyof LoadedTools> = [
   "lsp-outgoing-calls",
 ];
 
-export const ALWAYS_REQUEST_PERMISSION_TOOLS: Array<keyof LoadedTools> = ["shell"];
+export const ALWAYS_REQUEST_PERMISSION_TOOLS: Array<keyof LoadedTools> = [
+  "shell",
+  "background-process",
+];
 
 // Cap tool outputs so one huge result can't push history past the context limit and break autocompaction
 export const MAX_TOOL_OUTPUT_CONTEXT_FRACTION = 0.2;

--- a/source/tools/tool-defs/background-process.ts
+++ b/source/tools/tool-defs/background-process.ts
@@ -7,8 +7,8 @@ export default TOOL.declare({
   name: "background-process",
   description: `
 Runs a shell command in the background and returns immediately with a process id. The command is
-run by bash in the cwd, not connected to a PTY, and can't read stdin: only run commands that work
-headless.
+run by bash in the cwd, not connected to a PTY, and can't read stdin. You should only run commands in
+this tool that work headless.
 
 Use this for long-running commands you don't want to block on, like dev servers or file watchers.
 For commands that finish quickly, use the shell tool instead.

--- a/source/tools/tool-defs/background-process.ts
+++ b/source/tools/tool-defs/background-process.ts
@@ -6,9 +6,10 @@ import { backgroundProcesses } from "../../background-process.ts";
 export default TOOL.declare({
   name: "background-process",
   description: `
-Runs a shell command in the background and returns immediately with a process id. The command is
-run by bash in the cwd, not connected to a PTY, and can't read stdin. You should only run commands in
-this tool that work headless.
+Runs a shell command in the background and returns immediately with a process id. Give each process
+a short, descriptive label that is unique among the currently-running background processes. The
+command is run by bash in the cwd, not connected to a PTY, and can't read stdin. You should only run
+commands in this tool that work headless.
 
 Use this for long-running commands you don't want to block on, like dev servers or file watchers.
 For commands that finish quickly, use the shell tool instead.
@@ -18,17 +19,21 @@ poll output and status, or to kill the process. Background processes are killed 
 `.trim(),
   ArgumentsSchema: t.subtype({
     cmd: t.str.comment("The command to run in the background"),
+    label: t.str.comment(
+      'A short descriptive label unique among active background processes, like "dev-server" or "test-watcher"',
+    ),
   }),
 }).define(async () => ({
   async run({ toolCall }) {
-    const backgroundProcess = backgroundProcesses.manager().start(toolCall.parsed.arguments.cmd);
+    const { cmd, label } = toolCall.parsed.arguments;
+    const backgroundProcess = backgroundProcesses.manager().start(cmd, label);
     return ok({
       type: "output",
       content: [
         {
           type: "text",
           content:
-            `Started background process ${backgroundProcess.id}. ` +
+            `Started background process ${backgroundProcess.label} (${backgroundProcess.id}). ` +
             `Poll its output and status, or kill it, with manage-background-process.`,
         },
       ],

--- a/source/tools/tool-defs/background-process.ts
+++ b/source/tools/tool-defs/background-process.ts
@@ -1,0 +1,37 @@
+import { t } from "structural";
+import { TOOL } from "../common.ts";
+import { ok } from "../../libocto/result.ts";
+import { backgroundProcesses } from "../../background-process.ts";
+
+export default TOOL.declare({
+  name: "background-process",
+  description: `
+Runs a shell command in the background and returns immediately with a process id. The command is
+run by bash in the cwd, not connected to a PTY, and can't read stdin: only run commands that work
+headless.
+
+Use this for long-running commands you don't want to block on, like dev servers or file watchers.
+For commands that finish quickly, use the shell tool instead.
+
+stdout and stderr are captured; use the manage-background-process tool with the returned id to
+poll output and status, or to kill the process. Background processes are killed when Octo exits.
+`.trim(),
+  ArgumentsSchema: t.subtype({
+    cmd: t.str.comment("The command to run in the background"),
+  }),
+}).define(async () => ({
+  async run({ toolCall }) {
+    const backgroundProcess = backgroundProcesses.manager().start(toolCall.parsed.arguments.cmd);
+    return ok({
+      type: "output",
+      content: [
+        {
+          type: "text",
+          content:
+            `Started background process ${backgroundProcess.id}. ` +
+            `Poll its output and status, or kill it, with manage-background-process.`,
+        },
+      ],
+    });
+  },
+}));

--- a/source/tools/tool-defs/background-process.ts
+++ b/source/tools/tool-defs/background-process.ts
@@ -7,7 +7,8 @@ export default TOOL.declare({
   name: "background-process",
   description: `
 Runs a shell command in the background and returns immediately with a process id. Give each process
-a short, descriptive label that is unique among the currently-running background processes. The
+a short, descriptive label that is unique among the currently-running background processes; this label will
+primarily be used by the human user and not by any future LLMs querying running background processes. The
 command is run by bash in the cwd, not connected to a PTY, and can't read stdin. You should only run
 commands in this tool that work headless.
 
@@ -20,7 +21,10 @@ poll output and status, or to kill the process. Background processes are killed 
   ArgumentsSchema: t.subtype({
     cmd: t.str.comment("The command to run in the background"),
     label: t.str.comment(
-      'A short descriptive label unique among active background processes, like "dev-server" or "test-watcher"',
+      `
+A short descriptive label unique among active background processes allowing the user to understand 
+the purpose of the background process, like "dev-server" or "test-watcher"',
+`.trim(),
     ),
   }),
 }).define(async () => ({

--- a/source/tools/tool-defs/index.ts
+++ b/source/tools/tool-defs/index.ts
@@ -9,6 +9,8 @@ import fetch from "./fetch.ts";
 import rewrite from "./rewrite.ts";
 import skill from "./skill.ts";
 import webSearch from "./web-search.ts";
+import backgroundProcess from "./background-process.ts";
+import manageBackgroundProcess from "./manage-background-process.ts";
 import glob from "./glob.ts";
 import grep from "./grep.ts";
 import lspDefinition from "./lsp-definition.ts";
@@ -32,6 +34,8 @@ export default {
   rewrite,
   skill,
   "web-search": webSearch,
+  "background-process": backgroundProcess,
+  "manage-background-process": manageBackgroundProcess,
   glob,
   grep,
   "lsp-definition": lspDefinition,

--- a/source/tools/tool-defs/manage-background-process.ts
+++ b/source/tools/tool-defs/manage-background-process.ts
@@ -1,0 +1,96 @@
+import { t } from "structural";
+import { TOOL } from "../common.ts";
+import { ok, err } from "../../libocto/result.ts";
+import { MAX_SHELL_OUTPUT_LENGTH } from "../../transports/transport-common.ts";
+import {
+  backgroundProcesses,
+  type BackgroundProcess,
+  type BackgroundProcessStatus,
+} from "../../background-process.ts";
+
+export default TOOL.declare({
+  name: "manage-background-process",
+  description: `
+Manages background processes started with the background-process tool: check their status and
+output, kill them, or list the ones still running.
+`.trim(),
+  ArgumentsSchema: t.subtype({
+    id: t.optional(
+      t.str.comment("The background process id returned by the background-process tool"),
+    ),
+    timeout: t.optional(
+      t.num.comment(
+        'Optional, and only used by "poll": wait up to this many milliseconds for new output or exit before returning. If unset, poll returns immediately.',
+      ),
+    ),
+    action: t.value("poll").or(t.value("kill")).or(t.value("list")).comment(`
+"poll" returns the process's current status (running, or exited with its exit code/signal) plus
+any stdout/stderr appended since the last poll: output is drained each poll, so poll repeatedly to
+follow along. "kill" sends SIGTERM to the whole process group, escalating to SIGKILL after a grace
+period, and returns the same status/output snapshot. "list" shows all currently-running background processes,
+with its id and command. "poll" and "kill" require id; "list" ignores it.
+`),
+  }),
+}).define(async () => ({
+  async run({ signal, toolCall }) {
+    const { id, action, timeout } = toolCall.parsed.arguments;
+    const manager = backgroundProcesses.manager();
+    switch (action) {
+      case "list": {
+        return ok({
+          type: "output",
+          content: [{ type: "text", content: formatList(manager.list()) }],
+        });
+      }
+      case "poll": {
+        if (id == null) return err(`The id argument is required to poll a background process`);
+        const backgroundProcess = manager.poll(id);
+        if (backgroundProcess == null) return err(`No background process with id ${id}`);
+        if (timeout != null) await backgroundProcess.awaitActivity(timeout, signal);
+        return ok({
+          type: "output",
+          content: [{ type: "text", content: formatProcess(backgroundProcess) }],
+        });
+      }
+      case "kill": {
+        if (id == null) return err(`The id argument is required to kill a background process`);
+        const backgroundProcess = manager.kill(id);
+        if (backgroundProcess == null) return err(`No background process with id ${id}`);
+        return ok({
+          type: "output",
+          content: [{ type: "text", content: formatProcess(backgroundProcess) }],
+        });
+      }
+    }
+  },
+}));
+
+function formatList(entries: BackgroundProcess[]): string {
+  const running = entries.filter(entry => entry.status.state === "running");
+  if (running.length === 0) return "No background processes currently running.";
+  return [
+    "Running background processes:",
+    ...running.map(entry => `${entry.id}: ${entry.command}`),
+  ].join("\n");
+}
+
+function formatProcess(backgroundProcess: BackgroundProcess): string {
+  const latestOutput = backgroundProcess.drainUnreadOutput();
+  let content = `Background process ${backgroundProcess.id}: ${formatStatus(backgroundProcess.status)}
+Command: ${backgroundProcess.command}`;
+  if (backgroundProcess.outputExceeded) {
+    content += `\nOutput exceeded the ${MAX_SHELL_OUTPUT_LENGTH} character limit and was discarded; the process was terminated.`;
+  } else if (latestOutput.length > 0) {
+    content += `\nNew output:\n${latestOutput}`;
+  } else {
+    content += "\nNo new output.";
+  }
+  return content;
+}
+
+function formatStatus(status: BackgroundProcessStatus): string {
+  if (status.state === "running") return "running";
+  if (status.code != null) return `exited with code ${status.code}`;
+  if (status.signal != null) return `killed by signal ${status.signal}`;
+  return "exited";
+}

--- a/source/tools/tool-defs/manage-background-process.ts
+++ b/source/tools/tool-defs/manage-background-process.ts
@@ -27,7 +27,8 @@ output, kill them, or list the ones still running.
 "poll" returns the process's current status (running, or exited with its exit code/signal) plus
 any stdout/stderr appended since the last poll: output is drained each poll, so poll repeatedly to
 follow along. "kill" sends SIGTERM to the whole process group, escalating to SIGKILL after a grace
-period, and returns the same status/output snapshot. "list" shows all currently-running background processes,
+period, waits for the process to die, and returns its final status plus any remaining output.
+"list" shows all currently-running background processes,
 with its id and command. "poll" and "kill" require id; "list" ignores it.
 `),
   }),
@@ -54,7 +55,7 @@ with its id and command. "poll" and "kill" require id; "list" ignores it.
       }
       case "kill": {
         if (id == null) return err(`The id argument is required to kill a background process`);
-        const backgroundProcess = manager.kill(id);
+        const backgroundProcess = await manager.kill(id);
         if (backgroundProcess == null) return err(`No background process with id ${id}`);
         return ok({
           type: "output",

--- a/source/tools/tool-defs/manage-background-process.ts
+++ b/source/tools/tool-defs/manage-background-process.ts
@@ -18,6 +18,11 @@ output, kill them, or list the ones still running.
     id: t.optional(
       t.str.comment("The background process id returned by the background-process tool"),
     ),
+    label: t.optional(
+      t.str.comment(
+        "The background process label. Include it with poll and kill actions so it can be shown in the UI.",
+      ),
+    ),
     timeout: t.optional(
       t.num.comment(
         'Optional, and only used by "poll": wait up to this many milliseconds for new output or exit before returning. If unset, poll returns immediately.',
@@ -28,8 +33,8 @@ output, kill them, or list the ones still running.
 any stdout/stderr appended since the last poll: output is drained each poll, so poll repeatedly to
 follow along. "kill" sends SIGTERM to the whole process group, escalating to SIGKILL after a grace
 period, waits for the process to die, and returns its final status plus any remaining output.
-"list" shows all currently-running background processes,
-with its id and command. "poll" and "kill" require id; "list" ignores it.
+"list" shows all currently-running background processes with their ids, labels, and commands.
+"poll" and "kill" require id and should repeat the process label; "list" ignores both.
 `),
   }),
 }).define(async () => ({
@@ -71,13 +76,13 @@ function formatList(entries: BackgroundProcess[]): string {
   if (running.length === 0) return "No background processes currently running.";
   return [
     "Running background processes:",
-    ...running.map(entry => `${entry.id}: ${entry.command}`),
+    ...running.map(entry => `${entry.label} (${entry.id}): ${entry.command}`),
   ].join("\n");
 }
 
 function formatProcess(backgroundProcess: BackgroundProcess): string {
   const latestOutput = backgroundProcess.drainUnreadOutput();
-  let content = `Background process ${backgroundProcess.id}: ${formatStatus(backgroundProcess.status)}
+  let content = `Background process ${backgroundProcess.label} (${backgroundProcess.id}): ${formatStatus(backgroundProcess.status)}
 Command: ${backgroundProcess.command}`;
   if (backgroundProcess.outputExceeded) {
     content += `\nOutput exceeded the ${MAX_SHELL_OUTPUT_LENGTH} character limit and was discarded; the process was terminated.`;
@@ -91,6 +96,7 @@ Command: ${backgroundProcess.command}`;
 
 function formatStatus(status: BackgroundProcessStatus): string {
   if (status.state === "running") return "running";
+  if (status.error != null) return `failed: ${status.error}`;
   if (status.code != null) return `exited with code ${status.code}`;
   if (status.signal != null) return `killed by signal ${status.signal}`;
   return "exited";

--- a/source/tools/tool-defs/manage-background-process.ts
+++ b/source/tools/tool-defs/manage-background-process.ts
@@ -86,10 +86,11 @@ function formatProcess(backgroundProcess: BackgroundProcess): string {
 Command: ${backgroundProcess.command}`;
   if (backgroundProcess.outputExceeded) {
     content += `\nOutput exceeded the ${MAX_SHELL_OUTPUT_LENGTH} character limit and was discarded; the process was terminated.`;
-  } else if (latestOutput.length > 0) {
-    content += `\nNew output:\n${latestOutput}`;
-  } else {
+  } else if (latestOutput.stdout.length === 0 && latestOutput.stderr.length === 0) {
     content += "\nNo new output.";
+  } else {
+    if (latestOutput.stdout.length > 0) content += `\nNew stdout:\n${latestOutput.stdout}`;
+    if (latestOutput.stderr.length > 0) content += `\nNew stderr:\n${latestOutput.stderr}`;
   }
   return content;
 }

--- a/source/transports/transport-common.test.ts
+++ b/source/transports/transport-common.test.ts
@@ -64,4 +64,32 @@ describe("ShellOutput", () => {
     expect(() => new ShellOutput(0)).toThrow(RangeError);
     expect(() => new ShellOutput(Number.MAX_VALUE)).toThrow(RangeError);
   });
+
+  it("drains only output appended since the last drain", () => {
+    const output = new ShellOutput(100);
+    expect(output.hasUndrainedOutput()).toBe(false);
+    expect(output.drainNewOutput()).toBe("");
+
+    output.append("hello");
+    output.append(" world");
+    expect(output.hasUndrainedOutput()).toBe(true);
+    expect(output.drainNewOutput()).toBe("hello world");
+
+    expect(output.hasUndrainedOutput()).toBe(false);
+    expect(output.drainNewOutput()).toBe("");
+
+    output.append("again");
+    expect(output.hasUndrainedOutput()).toBe(true);
+    expect(output.drainNewOutput()).toBe("again");
+    expect(output.getOutput()).toBe("hello worldagain");
+  });
+
+  it("reports no unread output and drains to empty once the limit is exceeded", () => {
+    const output = new ShellOutput(5);
+    output.append("abcd");
+    expect(output.append("ef")).toBe(false);
+
+    expect(output.hasUndrainedOutput()).toBe(false);
+    expect(output.drainNewOutput()).toBe("");
+  });
 });

--- a/source/transports/transport-common.ts
+++ b/source/transports/transport-common.ts
@@ -6,6 +6,7 @@ export class ShellOutput {
   private readonly chunks: string[] = [];
   private length = 0;
   private exceededLimit = false;
+  private drainedChunkCount = 0;
 
   constructor(maxLength = MAX_SHELL_OUTPUT_LENGTH) {
     if (!Number.isSafeInteger(maxLength) || maxLength < 1) {
@@ -23,6 +24,7 @@ export class ShellOutput {
       this.exceededLimit = true;
       this.chunks.length = 0;
       this.length = 0;
+      this.drainedChunkCount = 0;
       return false;
     }
     this.chunks.push(value);
@@ -33,6 +35,17 @@ export class ShellOutput {
   getOutput(): string | null {
     if (this.exceededLimit) return null;
     return this.chunks.join("");
+  }
+
+  hasUndrainedOutput(): boolean {
+    return !this.exceededLimit && this.drainedChunkCount < this.chunks.length;
+  }
+
+  drainNewOutput(): string {
+    if (this.exceededLimit || this.drainedChunkCount >= this.chunks.length) return "";
+    const output = this.chunks.slice(this.drainedChunkCount).join("");
+    this.drainedChunkCount = this.chunks.length;
+    return output;
   }
 }
 


### PR DESCRIPTION
New tool pair for long-running shell commands:
- **background-process** spawns a command in its own process group (as an OctoProcess, so automatically terminates on Octo's exit)
- **manage-background-process**: has three actions [poll, kill, list] **polls** and **kills** existing running background processes, **lists** all running background process

Decided to make this as a pair of tools rather than coalesced into one in order to manage the permissions better.
The **background-process** tool requires permission whereas **manage-background-process** is always allowed to run.
