### PR TITLE
Vim mode is INSERT when input field is available

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -62,6 +62,7 @@ import {
   InflightResponseType,
   nextToolAction,
   QueuedUserMessage,
+  UiState,
   inputFieldAvailable,
 } from "./state.ts";
 import { SessionNotFoundError } from "./session-history/index.ts";
@@ -87,7 +88,7 @@ import { MultimediaInput } from "./components/multimedia-input.tsx";
 import { ImageInfo } from "./utils/image-utils.ts";
 import { Markdown } from "./markdown/index.tsx";
 import { LINE_SPLIT_REGEX, excerpt } from "./str.ts";
-import { VimModeIndicator } from "./components/vim-mode.tsx";
+import { VimModeIndicator, type InputMode } from "./components/vim-mode.tsx";
 import type { ToolCall } from "./libocto/tool-def.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import type { Content, MalformedToolRequest } from "./libocto/llm-ir.ts";
@@ -284,7 +285,6 @@ export default function App({
   const {
     history,
     modeData,
-    setVimMode,
     clearNonce,
     sessionHydrationNonce,
     modelOverride,
@@ -294,7 +294,6 @@ export default function App({
     useShallow(state => ({
       history: state.history,
       modeData: state.modeData,
-      setVimMode: state.setVimMode,
       clearNonce: state.clearNonce,
       sessionHydrationNonce: state.sessionHydrationNonce,
       modelOverride: state.modelOverride,
@@ -307,7 +306,6 @@ export default function App({
   });
   useEffect(() => {
     if (updates != null) markUpdatesSeen();
-    if (currConfig.vimEmulation?.enabled) setVimMode("INSERT");
   }, []);
   const matchedModel =
     modelOverride == null ? null : matchModelFromConfig(currConfig, modelOverride);
@@ -623,22 +621,58 @@ function QueuedUserMessages({ messages }: { messages: readonly QueuedUserMessage
     </Span>
   );
 }
+
+function useInputMode({
+  vimEnabled,
+  modeData,
+  clearNonce,
+}: {
+  vimEnabled: boolean;
+  modeData: UiState["modeData"];
+  clearNonce: number;
+}) {
+  const inputAvailable = inputFieldAvailable(modeData);
+  const [vimMode, setVimMode] = useState<"NORMAL" | "INSERT">("INSERT");
+
+  useEffect(() => {
+    if (!vimEnabled) return;
+    if (inputAvailable) setVimMode("INSERT");
+  }, [clearNonce, inputAvailable, vimEnabled]);
+
+  const inputMode: InputMode = vimEnabled
+    ? { kind: "vim", mode: inputAvailable ? vimMode : "NORMAL" }
+    : { kind: "emacs" };
+  const inputSubmitted = useCallback(() => {
+    if (vimEnabled) setVimMode("INSERT");
+  }, [vimEnabled]);
+
+  return { inputMode, setVimMode, inputSubmitted };
+}
+
+function getInterruptHintString(inputMode: InputMode, kittyKeyboardEnabled: boolean): string {
+  if (inputMode.kind === "vim" && inputMode.mode === "INSERT") {
+    return kittyKeyboardEnabled
+      ? "(Press Ctrl+ESC to interrupt)"
+      : "(Press ESC twice to interrupt)";
+  }
+  return "(Press ESC to interrupt)";
+}
+
 function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
+  const { paintCannon } = useApp();
   const config = useConfig();
   const model = useModel();
   const transport = useContext(TransportContext);
   const session = useSession();
   const showToast = useToast();
-  const vimEnabled = !!config.vimEmulation?.enabled;
   const {
     modeData,
+    clearNonce,
     input,
     abortResponse,
     openMenu,
     closeMenu,
     byteCount,
-    setVimMode,
-    vimMode: storedVimMode,
     query,
     setQuery,
     attachedImages,
@@ -650,13 +684,12 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   } = useAppStore(
     useShallow(state => ({
       modeData: state.modeData,
+      clearNonce: state.clearNonce,
       input: state.input,
       abortResponse: state.abortResponse,
       closeMenu: state.closeMenu,
       openMenu: state.openMenu,
       byteCount: state.byteCount,
-      setVimMode: state.setVimMode,
-      vimMode: state.vimMode,
       query: state.query,
       setQuery: state.setQuery,
       attachedImages: state.attachedImages,
@@ -667,15 +700,27 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       queueMessage: state.enqueueUserMessage,
     })),
   );
-  const vimMode = vimEnabled ? storedVimMode : "NORMAL";
+
+  const { inputMode, setVimMode, inputSubmitted } = useInputMode({
+    vimEnabled: config.vimEmulation?.enabled === true,
+    modeData,
+    clearNonce,
+  });
+
   useCtrlC(() => {
-    if (vimEnabled) return;
+    if (inputMode.kind === "vim") return;
     setQuery("");
   });
   useKeyboard(event => {
     if (event.key === "Escape") {
+      if (event.ctrlKey) {
+        abortResponse(session, config);
+        if (modeData.mode === "menu") closeMenu();
+        return;
+      }
+      if (event.defaultPrevented) return;
       // Vim INSERT mode: Esc ONLY returns to NORMAL (no menu, no abort)
-      if (vimEnabled && vimMode === "INSERT" && inputFieldAvailable(modeData)) {
+      if (inputMode.kind === "vim" && inputMode.mode === "INSERT") {
         setVimMode("NORMAL");
         return;
       }
@@ -690,6 +735,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   const onSubmit = useCallback(
     async (submittedQuery?: string, images?: ImageInfo[]) => {
       const finalQuery = submittedQuery ?? query;
+      inputSubmitted();
       setQuery("");
       if (modeData.mode !== "ready-for-request" && modeData.mode !== "menu") {
         queueMessage({ content: finalQuery, images });
@@ -715,7 +761,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
         throw error;
       }
     },
-    [query, modeData.mode, config, transport, session, setQuery, showToast],
+    [query, modeData.mode, config, transport, session, setQuery, showToast, inputSubmitted],
   );
   if (
     modeData.mode === "responding" ||
@@ -758,7 +804,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
                 color: "gray",
               }}
             >
-              (Press ESC to interrupt)
+              {getInterruptHintString(inputMode, paintCannon.kittyKeyboardEnabled)}
             </Span>
           </TerminalFlex>
         </TerminalFlex>
@@ -772,12 +818,11 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
           removeLastAttachedImage={removeLastAttachedImage}
           clearAttachedImages={clearAttachedImages}
           onSubmit={onSubmit}
-          vimEnabled={vimEnabled}
-          vimMode={vimMode}
+          inputMode={inputMode}
           setVimMode={setVimMode}
           modalities={model.modalities}
         />
-        <VimModeIndicator vimEnabled={vimEnabled} vimMode={vimMode} />
+        <VimModeIndicator inputMode={inputMode} />
       </TerminalFlex>
     );
   }
@@ -858,12 +903,11 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
         removeLastAttachedImage={removeLastAttachedImage}
         clearAttachedImages={clearAttachedImages}
         onSubmit={onSubmit}
-        vimEnabled={vimEnabled}
-        vimMode={vimMode}
+        inputMode={inputMode}
         setVimMode={setVimMode}
         modalities={model.modalities}
       />
-      <VimModeIndicator vimEnabled={vimEnabled} vimMode={vimMode} />
+      <VimModeIndicator inputMode={inputMode} />
     </TerminalFlex>
   );
 }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -650,17 +650,7 @@ function useInputMode({
   return { inputMode, setVimMode, inputSubmitted };
 }
 
-function getInterruptHintString(inputMode: InputMode, kittyKeyboardEnabled: boolean): string {
-  if (inputMode.kind === "vim" && inputMode.mode === "INSERT") {
-    return kittyKeyboardEnabled
-      ? "(Press Ctrl+ESC to interrupt)"
-      : "(Press ESC twice to interrupt)";
-  }
-  return "(Press ESC to interrupt)";
-}
-
 function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
-  const { paintCannon } = useApp();
   const config = useConfig();
   const model = useModel();
   const transport = useContext(TransportContext);
@@ -714,11 +704,6 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   });
   useKeyboard(event => {
     if (event.key === "Escape") {
-      if (event.ctrlKey) {
-        abortResponse(session, config);
-        if (modeData.mode === "menu") closeMenu();
-        return;
-      }
       if (event.defaultPrevented) return;
       // Vim INSERT mode: Esc ONLY returns to NORMAL (no menu, no abort)
       if (inputMode.kind === "vim" && inputMode.mode === "INSERT") {
@@ -805,7 +790,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
                 color: "gray",
               }}
             >
-              {getInterruptHintString(inputMode, paintCannon.kittyKeyboardEnabled)}
+              (Press ESC to interrupt)
             </Span>
           </TerminalFlex>
         </TerminalFlex>

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -88,7 +88,8 @@ import { MultimediaInput } from "./components/multimedia-input.tsx";
 import { ImageInfo } from "./utils/image-utils.ts";
 import { Markdown } from "./markdown/index.tsx";
 import { LINE_SPLIT_REGEX, excerpt } from "./str.ts";
-import { DEFAULT_INPUT_MODE, VimModeIndicator, type InputMode } from "./components/vim-mode.tsx";
+import { VimModeIndicator } from "./components/vim-mode.tsx";
+import { DEFAULT_INPUT_MODE, type InputMode, type VimMode } from "./components/input-mode.ts";
 import type { ToolCall } from "./libocto/tool-def.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import type { Content, MalformedToolRequest } from "./libocto/llm-ir.ts";
@@ -632,7 +633,7 @@ function useInputMode({
   clearNonce: number;
 }) {
   const inputAvailable = inputFieldAvailable(modeData);
-  const [vimMode, setVimMode] = useState<"NORMAL" | "INSERT">("INSERT");
+  const [vimMode, setVimMode] = useState<VimMode>("INSERT");
 
   useEffect(() => {
     if (!vimEnabled) return;

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -88,7 +88,7 @@ import { MultimediaInput } from "./components/multimedia-input.tsx";
 import { ImageInfo } from "./utils/image-utils.ts";
 import { Markdown } from "./markdown/index.tsx";
 import { LINE_SPLIT_REGEX, excerpt } from "./str.ts";
-import { VimModeIndicator, type InputMode } from "./components/vim-mode.tsx";
+import { DEFAULT_INPUT_MODE, VimModeIndicator, type InputMode } from "./components/vim-mode.tsx";
 import type { ToolCall } from "./libocto/tool-def.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import type { Content, MalformedToolRequest } from "./libocto/llm-ir.ts";
@@ -641,7 +641,7 @@ function useInputMode({
 
   const inputMode: InputMode = vimEnabled
     ? { kind: "vim", mode: inputAvailable ? vimMode : "NORMAL" }
-    : { kind: "emacs" };
+    : DEFAULT_INPUT_MODE;
   const inputSubmitted = useCallback(() => {
     if (vimEnabled) setVimMode("INSERT");
   }, [vimEnabled]);
@@ -702,7 +702,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   );
 
   const { inputMode, setVimMode, inputSubmitted } = useInputMode({
-    vimEnabled: config.vimEmulation?.enabled === true,
+    vimEnabled: !!config.vimEmulation?.enabled,
     modeData,
     clearNonce,
   });

--- a/source/components/exit-on-double-ctrl-c.tsx
+++ b/source/components/exit-on-double-ctrl-c.tsx
@@ -1,6 +1,5 @@
 import React, { useState, createContext, useContext } from "react";
-import { useShallow } from "zustand/react/shallow";
-import { useAppStore, inputFieldAvailable } from "../state.ts";
+import { useAppStore } from "../state.ts";
 import { useConfig } from "../config.ts";
 import { useSession } from "../session-context.ts";
 import { useApp } from "paintcannon-react";
@@ -21,14 +20,6 @@ export function ExitOnDoubleCtrlC({ children }: { children: React.ReactNode }) {
   const { exit } = useApp();
   const config = useConfig();
   const session = useSession();
-  const vimEnabled = !!config.vimEmulation?.enabled;
-  const { modeData, vimMode } = useAppStore(
-    useShallow(state => ({
-      modeData: state.modeData,
-      vimMode: state.vimMode,
-    })),
-  );
-  const isInsertMode = vimEnabled && inputFieldAvailable(modeData) && vimMode === "INSERT";
   useCtrlC(() => {
     if (ctrlCPressed) {
       /*
@@ -41,10 +32,8 @@ export function ExitOnDoubleCtrlC({ children }: { children: React.ReactNode }) {
       state.abortResponse(session, config, { exiting: true });
       exit();
     } else {
-      if (!isInsertMode) {
-        setCtrlCPressed(true);
-        setTimeout(() => setCtrlCPressed(false), 2000);
-      }
+      setCtrlCPressed(true);
+      setTimeout(() => setCtrlCPressed(false), 2000);
     }
   });
   return (

--- a/source/components/input-mode.ts
+++ b/source/components/input-mode.ts
@@ -1,0 +1,5 @@
+export type VimMode = "NORMAL" | "INSERT";
+
+export type InputMode = { kind: "emacs" } | { kind: "vim"; mode: VimMode };
+
+export const DEFAULT_INPUT_MODE: InputMode = { kind: "emacs" };

--- a/source/components/input-with-history.tsx
+++ b/source/components/input-with-history.tsx
@@ -7,7 +7,7 @@ import { ImageInfo } from "../utils/image-utils.ts";
 import type { PaintFile } from "paintcannon";
 import { useKeyboard } from "../hooks/use-keyboard.ts";
 import { TerminalFlex } from "./terminal-flex.tsx";
-import type { InputMode } from "./vim-mode.tsx";
+import type { InputMode, VimMode } from "./input-mode.ts";
 interface Props {
   attachedImages: ImageInfo[];
   inputHistory: InputHistory;
@@ -18,7 +18,7 @@ interface Props {
   onSubmit: (value?: string) => any;
   showLoadingImageBadge?: boolean;
   inputMode?: InputMode;
-  setVimMode?: (mode: "NORMAL" | "INSERT") => void;
+  setVimMode?: (mode: VimMode) => void;
 }
 export const InputWithHistory = React.memo((props: Props) => {
   const themeColor = useColor();

--- a/source/components/input-with-history.tsx
+++ b/source/components/input-with-history.tsx
@@ -7,6 +7,7 @@ import { ImageInfo } from "../utils/image-utils.ts";
 import type { PaintFile } from "paintcannon";
 import { useKeyboard } from "../hooks/use-keyboard.ts";
 import { TerminalFlex } from "./terminal-flex.tsx";
+import type { InputMode } from "./vim-mode.tsx";
 interface Props {
   attachedImages: ImageInfo[];
   inputHistory: InputHistory;
@@ -16,8 +17,7 @@ interface Props {
   onRemoveLastImage?: () => any;
   onSubmit: (value?: string) => any;
   showLoadingImageBadge?: boolean;
-  vimEnabled?: boolean;
-  vimMode?: "NORMAL" | "INSERT";
+  inputMode?: InputMode;
   setVimMode?: (mode: "NORMAL" | "INSERT") => void;
 }
 export const InputWithHistory = React.memo((props: Props) => {
@@ -181,8 +181,7 @@ export const InputWithHistory = React.memo((props: Props) => {
             // Prevent literal newlines from being inserted when accepting suggestions
             if (event.key === "Enter" && suggestionState?.isVisible) event.preventDefault();
           }}
-          vimEnabled={props.vimEnabled}
-          vimMode={props.vimMode}
+          inputMode={props.inputMode}
           setVimMode={props.setVimMode}
         />
       </TerminalFlex>

--- a/source/components/multimedia-input.tsx
+++ b/source/components/multimedia-input.tsx
@@ -11,7 +11,7 @@ import {
 } from "../providers.ts";
 import { Span } from "paintcannon-react";
 import { TerminalFlex } from "./terminal-flex.tsx";
-import { DEFAULT_INPUT_MODE, type InputMode } from "./vim-mode.tsx";
+import { DEFAULT_INPUT_MODE, type InputMode, type VimMode } from "./input-mode.ts";
 interface Props {
   inputHistory: InputHistory;
   value: string;
@@ -22,7 +22,7 @@ interface Props {
   clearAttachedImages: () => void;
   onSubmit: (text: string, images: ImageInfo[]) => any;
   inputMode?: InputMode;
-  setVimMode?: (mode: "NORMAL" | "INSERT") => void;
+  setVimMode?: (mode: VimMode) => void;
   modalities?: MultimodalConfig;
 }
 export const MultimediaInput = (props: Props) => {

--- a/source/components/multimedia-input.tsx
+++ b/source/components/multimedia-input.tsx
@@ -11,6 +11,7 @@ import {
 } from "../providers.ts";
 import { Span } from "paintcannon-react";
 import { TerminalFlex } from "./terminal-flex.tsx";
+import type { InputMode } from "./vim-mode.tsx";
 interface Props {
   inputHistory: InputHistory;
   value: string;
@@ -20,16 +21,16 @@ interface Props {
   removeLastAttachedImage: () => void;
   clearAttachedImages: () => void;
   onSubmit: (text: string, images: ImageInfo[]) => any;
-  vimEnabled?: boolean;
-  vimMode?: "NORMAL" | "INSERT";
+  inputMode?: InputMode;
   setVimMode?: (mode: "NORMAL" | "INSERT") => void;
   modalities?: MultimodalConfig;
 }
 export const MultimediaInput = (props: Props) => {
   const [showLoadingImageBadge, setShowLoadingImageBadge] = useState(false);
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
+  const inputMode = props.inputMode ?? { kind: "emacs" };
   useCtrlC(() => {
-    if (props.vimEnabled) return;
+    if (inputMode.kind === "vim") return;
     props.clearAttachedImages();
     setErrorMessages([]);
   });
@@ -104,8 +105,7 @@ export const MultimediaInput = (props: Props) => {
         onImageFilesAttached={handleImageFilesAttached}
         onSubmit={handleSubmit}
         onRemoveLastImage={handleRemoveLastImage}
-        vimEnabled={props.vimEnabled}
-        vimMode={props.vimMode}
+        inputMode={inputMode}
         setVimMode={props.setVimMode}
       />
     </TerminalFlex>

--- a/source/components/multimedia-input.tsx
+++ b/source/components/multimedia-input.tsx
@@ -11,7 +11,7 @@ import {
 } from "../providers.ts";
 import { Span } from "paintcannon-react";
 import { TerminalFlex } from "./terminal-flex.tsx";
-import type { InputMode } from "./vim-mode.tsx";
+import { DEFAULT_INPUT_MODE, type InputMode } from "./vim-mode.tsx";
 interface Props {
   inputHistory: InputHistory;
   value: string;
@@ -28,7 +28,7 @@ interface Props {
 export const MultimediaInput = (props: Props) => {
   const [showLoadingImageBadge, setShowLoadingImageBadge] = useState(false);
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
-  const inputMode = props.inputMode ?? { kind: "emacs" };
+  const inputMode = props.inputMode ?? DEFAULT_INPUT_MODE;
   useCtrlC(() => {
     if (inputMode.kind === "vim") return;
     props.clearAttachedImages();

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import type { PaintFile, PaintKeyboardEvent, TextAreaElement } from "paintcannon";
 import { Div, Span, Textarea, useApp } from "paintcannon-react";
-import { useVimKeyHandler, type InputMode } from "./vim-mode.tsx";
+import { DEFAULT_INPUT_MODE, useVimKeyHandler, type InputMode } from "./vim-mode.tsx";
 import { FOREGROUND_COLOR } from "../theme.ts";
 import { ImageInfo } from "../utils/image-utils.ts";
 
@@ -44,7 +44,7 @@ export default function TextInput({
   onImageFilesAttached,
   onRemoveLastImage,
   onSubmit,
-  inputMode = { kind: "emacs" },
+  inputMode = DEFAULT_INPUT_MODE,
   setVimMode,
   onKeyDown,
 }: Props) {

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import type { PaintFile, PaintKeyboardEvent, TextAreaElement } from "paintcannon";
 import { Div, Span, Textarea, useApp } from "paintcannon-react";
-import { useVimKeyHandler } from "./vim-mode.tsx";
+import { useVimKeyHandler, type InputMode } from "./vim-mode.tsx";
 import { FOREGROUND_COLOR } from "../theme.ts";
 import { ImageInfo } from "../utils/image-utils.ts";
 
@@ -19,8 +19,7 @@ type Props = {
   readonly onImageFilesAttached?: (files: PaintFile[]) => unknown;
   readonly onSubmit?: (value: string) => void;
   readonly showLoadingImageBadge?: boolean;
-  readonly vimEnabled?: boolean;
-  readonly vimMode?: "NORMAL" | "INSERT";
+  readonly inputMode?: InputMode;
   readonly setVimMode?: (mode: "NORMAL" | "INSERT") => void;
   readonly attachedImages?: ImageInfo[];
   readonly onRemoveLastImage?: () => unknown;
@@ -45,14 +44,13 @@ export default function TextInput({
   onImageFilesAttached,
   onRemoveLastImage,
   onSubmit,
-  vimEnabled = false,
-  vimMode = "NORMAL",
+  inputMode = { kind: "emacs" },
   setVimMode,
   onKeyDown,
 }: Props) {
   const { paintCannon } = useApp();
   const textareaRef = useRef<TextAreaElement>(null);
-  const vimHandler = useVimKeyHandler(vimMode, setVimMode ?? (() => {}));
+  const vimHandler = useVimKeyHandler(inputMode, setVimMode ?? (() => {}));
 
   useEffect(() => {
     if (focus) textareaRef.current?.focus();
@@ -130,7 +128,7 @@ export default function TextInput({
           }
 
           const cursorPosition = characterIndexToStringIndex(value, textarea.cursorPosition);
-          if (vimEnabled) {
+          if (inputMode.kind === "vim") {
             const cursorVisualPosition = textarea.getCursorVisualPosition();
             const nativeVisualLineRange =
               cursorVisualPosition === null
@@ -144,7 +142,7 @@ export default function TextInput({
                     end: characterIndexToStringIndex(value, nativeVisualLineRange.end),
                   };
             if (
-              vimMode === "NORMAL" &&
+              inputMode.mode === "NORMAL" &&
               (event.key === "j" ||
                 event.key === "ArrowDown" ||
                 event.key === "k" ||
@@ -186,7 +184,7 @@ export default function TextInput({
           }
 
           if (event.key === "Enter") {
-            if (vimEnabled && vimMode === "INSERT") return;
+            if (inputMode.kind === "vim" && inputMode.mode === "INSERT") return;
             event.preventDefault();
             onSubmit?.(value);
             return;

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import type { PaintFile, PaintKeyboardEvent, TextAreaElement } from "paintcannon";
 import { Div, Span, Textarea, useApp } from "paintcannon-react";
-import { DEFAULT_INPUT_MODE, useVimKeyHandler, type InputMode } from "./vim-mode.tsx";
+import { useVimKeyHandler } from "./vim-mode.tsx";
+import { DEFAULT_INPUT_MODE, type InputMode, type VimMode } from "./input-mode.ts";
 import { FOREGROUND_COLOR } from "../theme.ts";
 import { ImageInfo } from "../utils/image-utils.ts";
 
@@ -20,7 +21,7 @@ type Props = {
   readonly onSubmit?: (value: string) => void;
   readonly showLoadingImageBadge?: boolean;
   readonly inputMode?: InputMode;
-  readonly setVimMode?: (mode: "NORMAL" | "INSERT") => void;
+  readonly setVimMode?: (mode: VimMode) => void;
   readonly attachedImages?: ImageInfo[];
   readonly onRemoveLastImage?: () => unknown;
   readonly onKeyDown?: (event: PaintKeyboardEvent) => void;

--- a/source/components/vim-mode.test.tsx
+++ b/source/components/vim-mode.test.tsx
@@ -12,7 +12,7 @@ type VimHandler = ReturnType<typeof useVimKeyHandler>;
 function renderVimHandler(mode: "NORMAL" | "INSERT", setMode = mock()) {
   let handler: VimHandler | null = null;
   function Harness() {
-    handler = useVimKeyHandler(mode, setMode);
+    handler = useVimKeyHandler({ kind: "vim", mode }, setMode);
     return null;
   }
 
@@ -92,6 +92,88 @@ describe("useVimKeyHandler Ctrl-C handling", () => {
         row: 0,
         column: 4,
       },
+      { start: 0, end: 5 },
+    );
+
+    expect(result).toEqual({ consumed: false });
+    expect(rendered.setMode).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+});
+
+describe("useVimKeyHandler Escape handling", () => {
+  const escapeKey = (ctrlKey: boolean) =>
+    ({
+      key: "Escape",
+      ctrlKey,
+    }) as PaintKeyboardEvent;
+
+  it("consumes Escape in Insert mode and returns to Normal mode", () => {
+    const rendered = renderVimHandler("INSERT");
+
+    const result = rendered.handler.handle(
+      "Escape",
+      escapeKey(false),
+      5,
+      5,
+      "hello",
+      { row: 0, column: 5 },
+      { start: 0, end: 5 },
+    );
+
+    expect(result).toEqual({ consumed: true, newCursorPosition: 4 });
+    expect(rendered.setMode).toHaveBeenCalledWith("NORMAL");
+    rendered.unmount();
+  });
+
+  it("leaves Ctrl-Escape unconsumed in Insert mode for the app-level interrupt handler", () => {
+    const rendered = renderVimHandler("INSERT");
+
+    const result = rendered.handler.handle(
+      "Escape",
+      escapeKey(true),
+      5,
+      5,
+      "hello",
+      { row: 0, column: 5 },
+      { start: 0, end: 5 },
+    );
+
+    expect(result).toEqual({ consumed: false });
+    expect(rendered.setMode).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+
+  it("leaves Escape unconsumed in Normal mode for the app-level interrupt handler", () => {
+    const rendered = renderVimHandler("NORMAL");
+
+    const result = rendered.handler.handle(
+      "Escape",
+      escapeKey(false),
+      4,
+      5,
+      "hello",
+      { row: 0, column: 4 },
+      { start: 0, end: 5 },
+    );
+
+    expect(result).toEqual({ consumed: false });
+    expect(rendered.setMode).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+});
+
+describe("useVimKeyHandler submission", () => {
+  it("leaves Enter unconsumed for input submission", () => {
+    const rendered = renderVimHandler("NORMAL");
+
+    const result = rendered.handler.handle(
+      "Enter",
+      { key: "Enter", ctrlKey: false } as PaintKeyboardEvent,
+      5,
+      5,
+      "hello",
+      { row: 0, column: 5 },
       { start: 0, end: 5 },
     );
 

--- a/source/components/vim-mode.test.tsx
+++ b/source/components/vim-mode.test.tsx
@@ -103,18 +103,17 @@ describe("useVimKeyHandler Ctrl-C handling", () => {
 });
 
 describe("useVimKeyHandler Escape handling", () => {
-  const escapeKey = (ctrlKey: boolean) =>
-    ({
-      key: "Escape",
-      ctrlKey,
-    }) as PaintKeyboardEvent;
+  const escapeKey = {
+    key: "Escape",
+    ctrlKey: false,
+  } as PaintKeyboardEvent;
 
   it("consumes Escape in Insert mode and returns to Normal mode", () => {
     const rendered = renderVimHandler("INSERT");
 
     const result = rendered.handler.handle(
       "Escape",
-      escapeKey(false),
+      escapeKey,
       5,
       5,
       "hello",
@@ -127,30 +126,12 @@ describe("useVimKeyHandler Escape handling", () => {
     rendered.unmount();
   });
 
-  it("leaves Ctrl-Escape unconsumed in Insert mode for the app-level interrupt handler", () => {
-    const rendered = renderVimHandler("INSERT");
-
-    const result = rendered.handler.handle(
-      "Escape",
-      escapeKey(true),
-      5,
-      5,
-      "hello",
-      { row: 0, column: 5 },
-      { start: 0, end: 5 },
-    );
-
-    expect(result).toEqual({ consumed: false });
-    expect(rendered.setMode).not.toHaveBeenCalled();
-    rendered.unmount();
-  });
-
   it("leaves Escape unconsumed in Normal mode for the app-level interrupt handler", () => {
     const rendered = renderVimHandler("NORMAL");
 
     const result = rendered.handler.handle(
       "Escape",
-      escapeKey(false),
+      escapeKey,
       4,
       5,
       "hello",

--- a/source/components/vim-mode.test.tsx
+++ b/source/components/vim-mode.test.tsx
@@ -3,13 +3,14 @@ import TestRenderer, { act } from "react-test-renderer";
 import { describe, expect, it, mock } from "bun:test";
 import type { PaintKeyboardEvent } from "paintcannon";
 import { useVimKeyHandler } from "./vim-mode.tsx";
+import type { VimMode } from "./input-mode.ts";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
 
 type VimHandler = ReturnType<typeof useVimKeyHandler>;
 
-function renderVimHandler(mode: "NORMAL" | "INSERT", setMode = mock()) {
+function renderVimHandler(mode: VimMode, setMode = mock()) {
   let handler: VimHandler | null = null;
   function Harness() {
     handler = useVimKeyHandler({ kind: "vim", mode }, setMode);

--- a/source/components/vim-mode.tsx
+++ b/source/components/vim-mode.tsx
@@ -3,6 +3,9 @@ import type { CursorVisualPosition, PaintKeyboardEvent, VisualLineRange } from "
 import { useColor } from "../theme.ts";
 import { Span } from "paintcannon-react";
 import { TerminalFlex } from "./terminal-flex.tsx";
+
+export type InputMode = { kind: "emacs" } | { kind: "vim"; mode: "NORMAL" | "INSERT" };
+
 const isWhitespace = (char: string): boolean => /\s/.test(char);
 const isNewline = (char: string): boolean => char === "\n";
 const isWordChar = (char: string): boolean => /[a-zA-Z0-9_]/.test(char);
@@ -388,19 +391,13 @@ const operators: Record<string, Operator> = {
     };
   },
 };
-export function VimModeIndicator({
-  vimEnabled,
-  vimMode,
-}: {
-  vimEnabled: boolean;
-  vimMode: "NORMAL" | "INSERT";
-}) {
+export function VimModeIndicator({ inputMode }: { inputMode: InputMode }) {
   const themeColor = useColor();
-  if (!vimEnabled) return null;
+  if (inputMode.kind === "emacs") return null;
   return (
     <TerminalFlex
       style={{
-        visibility: vimMode === "INSERT" ? "visible" : "hidden",
+        visibility: inputMode.mode === "INSERT" ? "visible" : "hidden",
         height: 1,
         flexShrink: 0,
       }}
@@ -417,7 +414,7 @@ export function VimModeIndicator({
   );
 }
 export function useVimKeyHandler(
-  vimMode: "NORMAL" | "INSERT",
+  inputMode: InputMode,
   setVimMode: (mode: "NORMAL" | "INSERT") => void,
 ) {
   const pendingCommandRef = React.useRef<PendingCommand | null>(null);
@@ -452,8 +449,9 @@ export function useVimKeyHandler(
       newCursorPosition?: number;
       newValue?: string;
     } {
-      if (vimMode === "INSERT") {
-        if (key.key === "Escape" || (key.ctrlKey && input === "c")) {
+      if (inputMode.kind === "emacs") return { consumed: false };
+      if (inputMode.mode === "INSERT") {
+        if ((key.key === "Escape" && !key.ctrlKey) || (key.ctrlKey && input === "c")) {
           let newCursorPosition = cursorPosition;
           if (cursorPosition > 0) {
             const isAtVisualLineStart = cursorVisualPosition?.column === 0;
@@ -489,10 +487,17 @@ export function useVimKeyHandler(
           consumed: false,
         };
       }
-      if (key.key === "Enter")
+      if (key.key === "Escape") {
+        pendingCommandRef.current = null;
         return {
           consumed: false,
         };
+      }
+      if (key.key === "Enter") {
+        return {
+          consumed: false,
+        };
+      }
       if (key.ctrlKey && input === "c") {
         return {
           consumed: false,

--- a/source/components/vim-mode.tsx
+++ b/source/components/vim-mode.tsx
@@ -3,10 +3,7 @@ import type { CursorVisualPosition, PaintKeyboardEvent, VisualLineRange } from "
 import { useColor } from "../theme.ts";
 import { Span } from "paintcannon-react";
 import { TerminalFlex } from "./terminal-flex.tsx";
-
-export type InputMode = { kind: "emacs" } | { kind: "vim"; mode: "NORMAL" | "INSERT" };
-
-export const DEFAULT_INPUT_MODE: InputMode = { kind: "emacs" };
+import type { InputMode, VimMode } from "./input-mode.ts";
 
 const isWhitespace = (char: string): boolean => /\s/.test(char);
 const isNewline = (char: string): boolean => char === "\n";
@@ -415,10 +412,7 @@ export function VimModeIndicator({ inputMode }: { inputMode: InputMode }) {
     </TerminalFlex>
   );
 }
-export function useVimKeyHandler(
-  inputMode: InputMode,
-  setVimMode: (mode: "NORMAL" | "INSERT") => void,
-) {
+export function useVimKeyHandler(inputMode: InputMode, setVimMode: (mode: VimMode) => void) {
   const pendingCommandRef = React.useRef<PendingCommand | null>(null);
   const undoStackRef = React.useRef<TextState[]>([]);
   const redoStackRef = React.useRef<TextState[]>([]);

--- a/source/components/vim-mode.tsx
+++ b/source/components/vim-mode.tsx
@@ -447,7 +447,7 @@ export function useVimKeyHandler(inputMode: InputMode, setVimMode: (mode: VimMod
     } {
       if (inputMode.kind === "emacs") return { consumed: false };
       if (inputMode.mode === "INSERT") {
-        if ((key.key === "Escape" && !key.ctrlKey) || (key.ctrlKey && input === "c")) {
+        if (key.key === "Escape" || (key.ctrlKey && input === "c")) {
           let newCursorPosition = cursorPosition;
           if (cursorPosition > 0) {
             const isAtVisualLineStart = cursorVisualPosition?.column === 0;

--- a/source/components/vim-mode.tsx
+++ b/source/components/vim-mode.tsx
@@ -6,6 +6,8 @@ import { TerminalFlex } from "./terminal-flex.tsx";
 
 export type InputMode = { kind: "emacs" } | { kind: "vim"; mode: "NORMAL" | "INSERT" };
 
+export const DEFAULT_INPUT_MODE: InputMode = { kind: "emacs" };
+
 const isWhitespace = (char: string): boolean => /\s/.test(char);
 const isNewline = (char: string): boolean => char === "\n";
 const isWordChar = (char: string): boolean => /[a-zA-Z0-9_]/.test(char);

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -360,11 +360,10 @@ function filterSettings(config: Config) {
   return items;
 }
 function MainMenu() {
-  const { toggleMenu, notify, setVimMode } = useAppStore(
+  const { toggleMenu, notify } = useAppStore(
     useShallow(state => ({
       toggleMenu: state.toggleMenu,
       notify: state.notify,
-      setVimMode: state.setVimMode,
     })),
   );
   const session = useSession();
@@ -497,11 +496,6 @@ function MainMenu() {
             enabled: !wasEnabled,
           },
         });
-
-        // When switching from Emacs to Vim, default to INSERT mode
-        if (!wasEnabled) {
-          setVimMode("INSERT");
-        }
 
         // Notify user
         notify(`Switched to ${wasEnabled ? "Emacs" : "Vim"} mode`, session, config);

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -65,7 +65,6 @@ beforeEach(() => {
     query: "",
     attachedImages: [],
     modeData: { mode: "ready-for-request" },
-    vimMode: "INSERT",
   });
 });
 

--- a/source/state.ts
+++ b/source/state.ts
@@ -161,7 +161,6 @@ export type UiState = {
   modelOverride: string | null;
   quotaData: QuotaData | null;
   byteCount: number;
-  vimMode: "NORMAL" | "INSERT";
   query: string;
   attachedImages: ImageInfo[];
   queuedUserMessages: readonly QueuedUserMessage[];
@@ -182,7 +181,6 @@ export type UiState = {
   toggleMenu: () => void;
   openMenu: () => void;
   closeMenu: () => void;
-  setVimMode: (vimMode: "INSERT" | "NORMAL") => void;
   setModelOverride: (m: ModelConfig, session: Session) => void;
   setQuery: (query: string) => void;
   addAttachedImage: (image: ImageInfo) => void;
@@ -313,7 +311,6 @@ export const useAppStore = create<UiState>((set, get) => ({
   modeData: {
     mode: "ready-for-request" as const,
   },
-  vimMode: "INSERT" as const,
   runningToolCallId: null,
   history: [],
   modelOverride: null,
@@ -388,7 +385,7 @@ export const useAppStore = create<UiState>((set, get) => ({
 
   clearAuthError: () => {
     if (get().modeData.mode !== "auth-error") return;
-    set({ modeData: { mode: "ready-for-request" }, vimMode: "INSERT" });
+    set({ modeData: { mode: "ready-for-request" } });
   },
 
   editAndRetryFrom: (mode, _args) => {
@@ -404,7 +401,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         byteCount: 0,
         queuedUserMessages: [],
         modeData: { mode: "ready-for-request" },
-        vimMode: "INSERT",
       });
       return;
     }
@@ -416,7 +412,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         byteCount: 0,
         queuedUserMessages: [],
         modeData: { mode: "ready-for-request" },
-        vimMode: "INSERT",
       });
       return;
     }
@@ -430,7 +425,6 @@ export const useAppStore = create<UiState>((set, get) => ({
       queuedUserMessages: [],
       clearNonce: state.clearNonce + 1,
       modeData: { mode: "ready-for-request" },
-      vimMode: "INSERT",
     }));
   },
 
@@ -494,7 +488,6 @@ export const useAppStore = create<UiState>((set, get) => ({
       modeData: {
         mode: "ready-for-request",
       },
-      vimMode: "INSERT",
     });
     if (get().queuedUserMessages.length > 0) {
       get().runAgent(args);
@@ -559,7 +552,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         modeData: {
           mode: "ready-for-request",
         },
-        vimMode: "INSERT",
       });
     }
   },
@@ -571,7 +563,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         modeData: {
           mode: "ready-for-request",
         },
-        vimMode: "INSERT",
       });
       return true;
     }
@@ -606,10 +597,6 @@ export const useAppStore = create<UiState>((set, get) => ({
       modeData: { mode: "menu" },
       preMenuModeData: modeData,
     });
-  },
-
-  setVimMode: (vimMode: "INSERT" | "NORMAL") => {
-    set({ vimMode });
   },
 
   setQuery: query => {
@@ -704,7 +691,6 @@ export const useAppStore = create<UiState>((set, get) => ({
       clearNonce: state.clearNonce + 1,
       sessionAutoNotify: false,
       modeData: { mode: "ready-for-request" },
-      vimMode: "INSERT",
       preMenuModeData: null,
       // An aborted tool clears this itself when it settles, but until it does the new session
       // must not see the old session's in-flight ID.
@@ -938,7 +924,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         set({
           queuedUserMessages: [],
           modeData: { mode: "ready-for-request" },
-          vimMode: "INSERT",
         });
         return;
       }
@@ -948,7 +933,7 @@ export const useAppStore = create<UiState>((set, get) => ({
           return;
         }
         get().notifyReadyForInput(config);
-        set({ modeData: { mode: "ready-for-request" }, vimMode: "INSERT" });
+        set({ modeData: { mode: "ready-for-request" } });
         return;
       }
 


### PR DESCRIPTION
Once a message is sent in Vim mode, keep it in INSERT mode (now that we can queue messages). Because ESC previously interrupted an ongoing LLM response (even in Vim mode), we need a new instant control sequence to abort a response even in INSERT mode.

After some in-person bike shedding, folks agreed on **Ctrl+ESC** being that sequence. HOWEVER, this only works on kitty keyboard enabled terminals. For Mac's Terminal.app, we just change the hint to say `(Press ESC twice to interrupt)`.

Kitty Keyboard Terminal Behavior:


https://github.com/user-attachments/assets/9cd76c47-12a5-4592-8627-c349a0aa761a

Non-Kitty Keyboard Terminal Behavior:


https://github.com/user-attachments/assets/5abbcb05-5fb1-4720-a4b3-6abc19902730

